### PR TITLE
fix telegram integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ tgdb*
 .DS_Store
 .direnv
 result
+.fuse_hidden*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "nixEnvSelector.nixFile": "${workspaceFolder}/flake.nix"
+    "nixEnvSelector.nixFile": "${workspaceFolder}/flake.nix",
+    "rust-analyzer.testExplorer": true
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ dependencies = [
  "messanger-inteface",
  "serde",
  "serde_json",
+ "serial_test",
  "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
@@ -2110,6 +2111,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2171,12 @@ dependencies = [
  "hex",
  "spacetimedb-sdk",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "second-stack"
@@ -2288,6 +2304,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",

--- a/bins/sdb_server/src/lib.rs
+++ b/bins/sdb_server/src/lib.rs
@@ -215,8 +215,6 @@ struct BasicClaims {
     name: Option<String>,
 }
 
-const DIRTY_TOKEN_ISSUER: &str = env!("DIRTY_TOKEN");
-
 #[reducer(client_connected)]
 // Called when a client connects to a SpacetimeDB database
 pub fn client_connected(ctx: &ReducerContext) -> Result<(), String> {

--- a/flake.lock
+++ b/flake.lock
@@ -68,6 +68,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1767364772,
@@ -90,10 +108,47 @@
         "crane": "crane",
         "crm-chat-web": "crm-chat-web",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "sccache": "sccache"
+      }
+    },
+    "sccache": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768055794,
+        "narHash": "sha256-cpYlVHsK37W1e2lmXhI07xdHMx58kdyr0fECJtbzGPc=",
+        "owner": "mozilla",
+        "repo": "sccache",
+        "rev": "d9d2eb6ffb71f3d1a8a4174848941bfc67b25eb0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mozilla",
+        "repo": "sccache",
+        "type": "github"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,11 @@
       flake = false;
     };
 
+    sccache = {
+      url = "github:mozilla/sccache";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # Child flakes
     crm-chat-web = {
       url = "path:./bins/crm-chat-web";
@@ -29,6 +34,7 @@
     crane,
     flake-utils,
     advisory-db,
+    sccache,
     crm-chat-web,
     ...
   } @ inputs:
@@ -37,6 +43,7 @@
         pkgs = import nixpkgs {
           inherit system;
           config.allowUnfree = true;
+          overlays = [ sccache.overlays.default ];
         };
 
         inherit (pkgs) lib;
@@ -63,6 +70,7 @@
               pkgs.webkitgtk_4_1
               pkgs.libsoup_3
               pkgs.cairo
+              pkgs.sccache
             ]
             ++ lib.optionals pkgs.stdenv.isDarwin [
               # Additional darwin specific inputs can be set here
@@ -70,7 +78,7 @@
             ];
 
           # Additional environment variables can be set directly
-          # MY_CUSTOM_VAR = "some value";
+          RUSTC_WRAPPER = "${pkgs.sccache}/bin/sccache";
         };
 
         # Build *just* the cargo dependencies, so we can reuse
@@ -171,6 +179,7 @@
         devShells.default = craneLib.devShell {
           RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+          RUSTC_WRAPPER = "${pkgs.sccache}/bin/sccache";
 
           shellHook = ''
             export PATH="$HOME/.local/bin:$PATH"

--- a/libs/messanger-telegram/Cargo.toml
+++ b/libs/messanger-telegram/Cargo.toml
@@ -25,3 +25,4 @@ grammers-tl-types = { git = "https://github.com/Lonami/grammers", features = [
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
+serial_test = "3"

--- a/libs/messanger-telegram/src/lib.rs
+++ b/libs/messanger-telegram/src/lib.rs
@@ -19,6 +19,8 @@ use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use tokio_stream::{self as stream};
 
+use tokio::task::JoinHandle;
+
 /// Telegram client implementation of the MessengerClient trait.
 pub struct TelegramClient {
     client: Arc<Mutex<Client>>,
@@ -28,6 +30,8 @@ pub struct TelegramClient {
     #[allow(dead_code)]
     session_store: Option<Arc<dyn SessionStore + Send + Sync>>,
     updates_rx: Arc<Mutex<Option<mpsc::UnboundedReceiver<UpdatesLike>>>>,
+    #[allow(dead_code)]
+    pool_runner_handle: JoinHandle<()>,
 }
 
 impl TelegramClient {
@@ -39,8 +43,12 @@ impl TelegramClient {
 }
 
 impl TelegramClient {
-    async fn get_dialog(&self, chat_external_id: &ExternalId) -> Result<Dialog, MessengerError> {
-        let client = self.client.lock().await;
+    /// Find a dialog by external ID using an already-locked client.
+    /// This is used internally to avoid deadlocks when the caller already holds the lock.
+    async fn find_dialog_with_client(
+        client: &Client,
+        chat_external_id: &ExternalId,
+    ) -> Result<Dialog, MessengerError> {
         let mut dialogs = client.iter_dialogs();
         let mut found_dialog = None;
         while let Ok(Some(dialog)) = dialogs.next().await {
@@ -49,10 +57,14 @@ impl TelegramClient {
                 break;
             }
         }
-        let dialog = found_dialog.ok_or_else(|| {
+        found_dialog.ok_or_else(|| {
             MessengerError::NotFound(format!("Chat not found: {}", chat_external_id))
-        })?;
-        Ok(dialog)
+        })
+    }
+
+    async fn get_dialog(&self, chat_external_id: &ExternalId) -> Result<Dialog, MessengerError> {
+        let client = self.client.lock().await;
+        Self::find_dialog_with_client(&client, chat_external_id).await
     }
 }
 
@@ -183,7 +195,7 @@ impl MessengerClient for TelegramClient {
         let mut messages_vec = Vec::new();
         {
             let client = client_arc.lock().await;
-            let dialog = self.get_dialog(chat_external_id).await?;
+            let dialog = Self::find_dialog_with_client(&client, chat_external_id).await?;
 
             // Keep dialog alive while we use its chat
             let chat = dialog.peer();
@@ -490,7 +502,7 @@ impl MessengerClient for TelegramClient {
             .parse()
             .map_err(|e| MessengerError::Serialization(format!("Invalid chat ID: {}", e)))?;
 
-        let dialog = self.get_dialog(chat_external_id).await?;
+        let dialog = Self::find_dialog_with_client(&client, chat_external_id).await?;
 
         // Send the message
         let chat = dialog.peer();
@@ -530,7 +542,7 @@ impl MessengerClient for TelegramClient {
                 .map_err(|e| MessengerError::Serialization(format!("Invalid message ID: {}", e)))?
         };
 
-        let dialog = self.get_dialog(chat_external_id).await?;
+        let dialog = Self::find_dialog_with_client(&client, chat_external_id).await?;
         // Edit the message
         let chat = dialog.peer();
         client
@@ -567,7 +579,7 @@ impl MessengerClient for TelegramClient {
                 .map_err(|e| MessengerError::Serialization(format!("Invalid message ID: {}", e)))?
         };
 
-        let dialog = self.get_dialog(chat_external_id).await?;
+        let dialog = Self::find_dialog_with_client(&client, chat_external_id).await?;
 
         // Delete the message
         let chat = dialog.peer();
@@ -675,6 +687,7 @@ impl MessengerClientBuilder for TelegramClientBuilder {
         let updates_rx = Arc::new(Mutex::new(Some(updates_rx)));
 
         let client = Client::new(&pool);
+        let pool_runner_handle = tokio::spawn(pool.runner.run());
 
         // Store the session store if provided
         let stored_session_store = session_store
@@ -696,6 +709,7 @@ impl MessengerClientBuilder for TelegramClientBuilder {
             api_hash: api_hash,
             session_store: stored_session_store,
             updates_rx,
+            pool_runner_handle,
         })
     }
 }

--- a/libs/messanger-telegram/tests/integration_test.rs
+++ b/libs/messanger-telegram/tests/integration_test.rs
@@ -3,13 +3,21 @@
 //! These tests require valid Telegram API credentials and will make actual
 //! API calls to Telegram. Set up your test configuration before running these tests.
 
-use base64::{engine::general_purpose::STANDARD, Engine as _};
 use messanger_inteface::{
-    session::JsonSessionStore, AuthConfig, MessengerClient, MessengerClientBuilder, Update,
+    session::JsonSessionStore, AuthConfig, MessengerClient, MessengerClientBuilder, SessionStore,
+    Update,
 };
 use messanger_telegram::TelegramClientBuilder;
 use serde_json::json;
+use serial_test::serial;
+use std::time::Duration;
 use tokio_stream::StreamExt;
+
+/// Default timeout for most tests (60 seconds)
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Extended timeout for tests involving multiple operations (120 seconds)
+const EXTENDED_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Test configuration for Telegram clients.
 /// This should be populated with actual credentials from environment variables
@@ -31,12 +39,12 @@ impl TestConfig {
     /// - TG_API_HASH_2: API hash for second client
     /// - TG_SESSION_FILE_2: Session file for second client
     fn from_env() -> Option<(TestConfig, TestConfig)> {
-        let api_id_1 = env!("TG_API_ID_1").parse().ok()?;
-        let api_hash_1 = env!("TG_API_HASH_1").to_string();
-        let session_file_1 = env!("TG_SESSION_FILE_1").to_string();
-        let api_id_2 = env!("TG_API_ID_2").parse().ok()?;
-        let api_hash_2 = env!("TG_API_HASH_2").to_string();
-        let session_file_2 = env!("TG_SESSION_FILE_2").to_string();
+        let api_id_1 = std::env::var("TG_API_ID_1").ok()?.parse().ok()?;
+        let api_hash_1 = std::env::var("TG_API_HASH_1").ok()?;
+        let session_file_1 = std::env::var("TG_SESSION_FILE_1").ok()?;
+        let api_id_2 = std::env::var("TG_API_ID_2").ok()?.parse().ok()?;
+        let api_hash_2 = std::env::var("TG_API_HASH_2").ok()?;
+        let session_file_2 = std::env::var("TG_SESSION_FILE_2").ok()?;
         Some((
             TestConfig {
                 api_id: api_id_1,
@@ -59,241 +67,232 @@ impl TestConfig {
             }),
         }
     }
+
+    fn to_session_config(&self) -> Option<Box<dyn SessionStore>> {
+        Some(Box::new(JsonSessionStore::new(json!({
+            "session_file": &self.session_file
+        }))))
+    }
 }
 
 #[tokio::test]
+#[serial]
 async fn test_client_creation() {
-    let configs = TestConfig::from_env();
-    if configs.is_none() {
-        eprintln!("Skipping test: TG_API_ID_1, TG_API_HASH_1, TG_API_ID_2, TG_API_HASH_2 not set");
-        return;
-    }
+    tokio::time::timeout(DEFAULT_TIMEOUT, async {
+        let configs = TestConfig::from_env();
 
-    let (config1, config2) = configs.unwrap();
-    let builder = TelegramClientBuilder::new();
+        if configs.is_none() {
+            println!("Skipping test: Environment variables not set");
+            return;
+        }
 
-    let bytes = tokio::fs::read(&config1.session_file)
-        .await
-        .expect("Failed to read session file");
+        let (config1, config2) = configs.unwrap();
+        let builder = TelegramClientBuilder::new();
 
-    // Create first client
-    let session_store1 = Box::new(JsonSessionStore::new(json!({
-        "session_data": STANDARD.encode(&bytes)
-    })));
-    let client1 = builder
-        .build(config1.to_auth_config(), Some(session_store1))
-        .await
-        .expect("Failed to create first client");
+        // Create first client
+        let client1 = builder
+            .build(config1.to_auth_config(), config1.to_session_config())
+            .await
+            .expect("Failed to create first client");
 
-    let bytes = tokio::fs::read(&config2.session_file)
-        .await
-        .expect("Failed to read session file");
-    // Create second client
-    let session_store2 = Box::new(JsonSessionStore::new(json!({
-        "session_data": STANDARD.encode(&bytes)
-    })));
-    let client2 = builder
-        .build(config2.to_auth_config(), Some(session_store2))
-        .await
-        .expect("Failed to create second client");
+        // Create second client
+        let client2 = builder
+            .build(config2.to_auth_config(), config2.to_session_config())
+            .await
+            .expect("Failed to create second client");
 
-    // Test that clients are created
-    assert!(client1.is_authorized().await.is_ok());
-    assert!(client2.is_authorized().await.is_ok());
+        // Test that clients are created
+        assert!(client1.is_authorized().await.is_ok());
+        assert!(client2.is_authorized().await.is_ok());
+    })
+    .await
+    .expect("Test timed out");
 }
 
 #[tokio::test]
+#[serial]
 async fn test_client_external_ids() {
-    let configs = TestConfig::from_env();
-    if configs.is_none() {
-        eprintln!("Skipping test: TG_API_ID_1, TG_API_HASH_1, TG_API_ID_2, TG_API_HASH_2 not set");
-        return;
-    }
+    tokio::time::timeout(DEFAULT_TIMEOUT, async {
+        let configs = TestConfig::from_env();
 
-    let (config1, config2) = configs.unwrap();
-    let builder = TelegramClientBuilder::new();
+        if configs.is_none() {
+            println!("Skipping test: Environment variables not set");
+            return;
+        }
 
-    let bytes = tokio::fs::read(&config1.session_file)
-        .await
-        .expect("Failed to read session file");
+        let (config1, config2) = configs.unwrap();
+        let builder = TelegramClientBuilder::new();
 
-    // Create first client
-    let session_store1 = Box::new(JsonSessionStore::new(json!({
-        "session_data": STANDARD.encode(&bytes)
-    })));
-    let client1 = builder
-        .build(config1.to_auth_config(), Some(session_store1))
-        .await
-        .expect("Failed to create first client");
+        // Create first client
+        let client1 = builder
+            .build(config1.to_auth_config(), config1.to_session_config())
+            .await
+            .expect("Failed to create first client");
 
-    let bytes = tokio::fs::read(&config2.session_file)
-        .await
-        .expect("Failed to read session file");
-    // Create second client
-    let session_store2 = Box::new(JsonSessionStore::new(json!({
-        "session_data": STANDARD.encode(&bytes)
-    })));
-    let client2 = builder
-        .build(config2.to_auth_config(), Some(session_store2))
-        .await
-        .expect("Failed to create second client");
+        // Create second client
+        let client2 = builder
+            .build(config2.to_auth_config(), config2.to_session_config())
+            .await
+            .expect("Failed to create second client");
 
-    // Get external IDs (should be different for different accounts)
-    let id1 = client1
-        .get_client_external_id()
-        .await
-        .expect("Failed to get client1 external ID");
-    let id2 = client2
-        .get_client_external_id()
-        .await
-        .expect("Failed to get client2 external ID");
+        // Get external IDs (should be different for different accounts)
+        let id1 = client1
+            .get_client_external_id()
+            .await
+            .expect("Failed to get client1 external ID");
+        let id2 = client2
+            .get_client_external_id()
+            .await
+            .expect("Failed to get client2 external ID");
 
-    // Both should start with "telegram:"
-    assert!(id1.starts_with("telegram:"));
-    assert!(id2.starts_with("telegram:"));
-
-    // They should be different (assuming different accounts)
-    assert_ne!(
-        id1, id2,
-        "Both clients have the same external ID - they should be different accounts"
-    );
+        // Both should start with "telegram:"
+        assert!(id1.starts_with("telegram:"));
+        assert!(id2.starts_with("telegram:"));
+        println!("Client 1 external ID: {}", id1);
+        println!("Client 2 external ID: {}", id2);
+        // They should be different (assuming different accounts)
+        assert_ne!(
+            id1, id2,
+            "Both clients have the same external ID - they should be different accounts"
+        );
+    })
+    .await
+    .expect("Test timed out");
 }
 
 #[tokio::test]
+#[serial]
 async fn test_iter_dialogs() {
-    let configs = TestConfig::from_env();
-    if configs.is_none() {
-        eprintln!("Skipping test: TG_API_ID_1, TG_API_HASH_1, TG_API_ID_2, TG_API_HASH_2 not set");
-        return;
-    }
+    tokio::time::timeout(DEFAULT_TIMEOUT, async {
+        let configs = TestConfig::from_env();
 
-    let (config1, _config2) = configs.unwrap();
-    let builder = TelegramClientBuilder::new();
-
-    let bytes = tokio::fs::read(&config1.session_file)
-        .await
-        .expect("Failed to read session file");
-    let session_store = Box::new(JsonSessionStore::new(json!({
-        "session_data": STANDARD.encode(&bytes)
-    })));
-    let client = builder
-        .build(config1.to_auth_config(), Some(session_store))
-        .await
-        .expect("Failed to create client");
-
-    // Check authorization first
-    let is_authorized = client
-        .is_authorized()
-        .await
-        .expect("Failed to check authorization");
-
-    if !is_authorized {
-        eprintln!("Skipping test: Client is not authorized");
-        return;
-    }
-
-    // Iterate dialogs
-    let mut dialogs = client
-        .iter_dialogs()
-        .await
-        .expect("Failed to get dialogs stream");
-
-    let mut dialog_count = 0;
-    while let Some(dialog_result) = dialogs.next().await {
-        let dialog = dialog_result.expect("Failed to get dialog");
-
-        // Verify dialog structure
-        assert!(!dialog.external_id.is_empty());
-        assert!(dialog.chat_type.is_some());
-
-        dialog_count += 1;
-
-        // Limit to first 10 dialogs for testing
-        if dialog_count >= 10 {
-            break;
+        if configs.is_none() {
+            println!("Skipping test: Environment variables not set");
+            return;
         }
-    }
 
-    println!("Found {} dialogs", dialog_count);
+        let (config1, _config2) = configs.unwrap();
+        let builder = TelegramClientBuilder::new();
+
+        // Create first client
+        let client = builder
+            .build(config1.to_auth_config(), config1.to_session_config())
+            .await
+            .expect("Failed to create first client");
+
+        // Check authorization first
+        let is_authorized = client
+            .is_authorized()
+            .await
+            .expect("Failed to check authorization");
+
+        if !is_authorized {
+            panic!("Client is not authorized");
+        }
+
+        // Iterate dialogs
+        let mut dialogs = client
+            .iter_dialogs()
+            .await
+            .expect("Failed to get dialogs stream");
+
+        let mut dialog_count = 0;
+        while let Some(dialog_result) = dialogs.next().await {
+            let dialog = dialog_result.expect("Failed to get dialog");
+
+            // Verify dialog structure
+            assert!(!dialog.external_id.is_empty());
+            assert!(dialog.chat_type.is_some());
+
+            dialog_count += 1;
+
+            // Limit to first 10 dialogs for testing
+            if dialog_count >= 10 {
+                break;
+            }
+        }
+
+        println!("Found {} dialogs", dialog_count);
+    })
+    .await
+    .expect("Test timed out");
 }
 
 #[tokio::test]
+#[serial]
 async fn test_iter_messages() {
-    let configs = TestConfig::from_env();
-    if configs.is_none() {
-        eprintln!("Skipping test: TG_API_ID_1, TG_API_HASH_1, TG_API_ID_2, TG_API_HASH_2 not set");
-        return;
-    }
+    tokio::time::timeout(DEFAULT_TIMEOUT, async {
+        let configs = TestConfig::from_env();
 
-    let (config1, _config2) = configs.unwrap();
-    let builder = TelegramClientBuilder::new();
-
-    let bytes = tokio::fs::read(&config1.session_file)
-        .await
-        .expect("Failed to read session file");
-    let session_store = Box::new(JsonSessionStore::new(json!({
-        "session_data": STANDARD.encode(&bytes)
-    })));
-    let client = builder
-        .build(config1.to_auth_config(), Some(session_store))
-        .await
-        .expect("Failed to create client");
-
-    // Check authorization
-    let is_authorized = client
-        .is_authorized()
-        .await
-        .expect("Failed to check authorization");
-
-    if !is_authorized {
-        eprintln!("Skipping test: Client is not authorized");
-        return;
-    }
-
-    // Get first dialog to test messages
-    let mut dialogs = client
-        .iter_dialogs()
-        .await
-        .expect("Failed to get dialogs stream");
-
-    let first_dialog = match dialogs.next().await {
-        Some(Ok(dialog)) => dialog,
-        Some(Err(e)) => {
-            eprintln!("Failed to get first dialog: {}", e);
+        if configs.is_none() {
+            println!("Skipping test: Environment variables not set");
             return;
         }
-        None => {
-            eprintln!("No dialogs found");
-            return;
+
+        let (config1, _config2) = configs.unwrap();
+        let builder = TelegramClientBuilder::new();
+
+        // Create first client
+        let client = builder
+            .build(config1.to_auth_config(), config1.to_session_config())
+            .await
+            .expect("Failed to create first client");
+
+        // Check authorization
+        let is_authorized = client
+            .is_authorized()
+            .await
+            .expect("Failed to check authorization");
+
+        if !is_authorized {
+            panic!("Client is not authorized");
         }
-    };
 
-    println!("First dialog: {:?}", first_dialog);
-    // Get messages for the first dialog
-    let mut messages = client
-        .iter_messages(&first_dialog.external_id)
-        .await
-        .expect("Failed to get messages stream");
+        // Get first dialog to test messages
+        let mut dialogs = client
+            .iter_dialogs()
+            .await
+            .expect("Failed to get dialogs stream");
 
-    let mut message_count = 0;
-    while let Some(message_result) = messages.next().await {
-        let message = message_result.expect("Failed to get message");
-        // Verify message structure
-        assert!(!message.external_id.is_empty());
-        assert_eq!(message.chat_external_id, first_dialog.external_id);
+        let first_dialog = match dialogs.next().await {
+            Some(Ok(dialog)) => dialog,
+            Some(Err(e)) => {
+                panic!("Failed to get first dialog: {}", e);
+            }
+            None => {
+                panic!("No dialogs found");
+            }
+        };
 
-        message_count += 1;
+        println!("First dialog: {:?}", first_dialog);
+        // Get messages for the first dialog
+        let mut messages = client
+            .iter_messages(&first_dialog.external_id)
+            .await
+            .expect("Failed to get messages stream");
 
-        // Limit to first 10 messages for testing
-        if message_count >= 10 {
-            break;
+        let mut message_count = 0;
+        while let Some(message_result) = messages.next().await {
+            let message = message_result.expect("Failed to get message");
+            // Verify message structure
+            assert!(!message.external_id.is_empty());
+            assert_eq!(message.chat_external_id, first_dialog.external_id);
+
+            message_count += 1;
+
+            // Limit to first 10 messages for testing
+            if message_count >= 10 {
+                break;
+            }
         }
-    }
 
-    println!(
-        "Found {} messages in dialog {}",
-        message_count, first_dialog.external_id
-    );
+        println!(
+            "Found {} messages in dialog {}",
+            message_count, first_dialog.external_id
+        );
+    })
+    .await
+    .expect("Test timed out");
 }
 
 // #[tokio::test]
@@ -328,504 +327,491 @@ async fn test_iter_messages() {
 // }
 
 #[tokio::test]
+#[serial]
 async fn test_native_chat_access() {
-    let configs = TestConfig::from_env();
-    if configs.is_none() {
-        eprintln!("Skipping test: TG_API_ID_1, TG_API_HASH_1, TG_API_ID_2, TG_API_HASH_2 not set");
-        return;
-    }
+    tokio::time::timeout(DEFAULT_TIMEOUT, async {
+        let configs = TestConfig::from_env();
 
-    let (config1, _config2) = configs.unwrap();
-    let builder = TelegramClientBuilder::new();
-
-    let bytes = tokio::fs::read(&config1.session_file)
-        .await
-        .expect("Failed to read session file");
-    let session_store = Box::new(JsonSessionStore::new(json!({
-        "session_data": STANDARD.encode(&bytes)
-    })));
-    let client = builder
-        .build(config1.to_auth_config(), Some(session_store))
-        .await
-        .expect("Failed to create client");
-
-    // Check authorization
-    let is_authorized = client
-        .is_authorized()
-        .await
-        .expect("Failed to check authorization");
-
-    if !is_authorized {
-        eprintln!("Skipping test: Client is not authorized");
-        return;
-    }
-
-    // Get first dialog
-    let mut dialogs = client
-        .iter_dialogs()
-        .await
-        .expect("Failed to get dialogs stream");
-
-    let first_dialog = match dialogs.next().await {
-        Some(Ok(dialog)) => dialog,
-        Some(Err(e)) => {
-            eprintln!("Failed to get first dialog: {}", e);
+        if configs.is_none() {
+            println!("Skipping test: Environment variables not set");
             return;
         }
-        None => {
-            eprintln!("No dialogs found");
-            return;
+
+        let (config1, _config2) = configs.unwrap();
+        let builder = TelegramClientBuilder::new();
+
+        // Create first client
+        let client = builder
+            .build(config1.to_auth_config(), config1.to_session_config())
+            .await
+            .expect("Failed to create first client");
+        // Check authorization
+        let is_authorized = client
+            .is_authorized()
+            .await
+            .expect("Failed to check authorization");
+
+        if !is_authorized {
+            panic!("Client is not authorized");
         }
-    };
 
-    // Get native chat payload
-    let native_chat = client
-        .get_native_chat(&first_dialog.external_id)
-        .await
-        .expect("Failed to get native chat");
+        // Get first dialog
+        let mut dialogs = client
+            .iter_dialogs()
+            .await
+            .expect("Failed to get dialogs stream");
 
-    // Verify native payload structure
-    assert!(
-        native_chat.payload.is_object(),
-        "Native chat payload should be a JSON object"
-    );
-    println!("Native chat payload: {}", native_chat.payload);
-}
-
-#[tokio::test]
-async fn test_native_message_access() {
-    let configs = TestConfig::from_env();
-    if configs.is_none() {
-        eprintln!("Skipping test: TG_API_ID_1, TG_API_HASH_1, TG_API_ID_2, TG_API_HASH_2 not set");
-        return;
-    }
-
-    let (config1, _config2) = configs.unwrap();
-    let builder = TelegramClientBuilder::new();
-
-    let bytes = tokio::fs::read(&config1.session_file)
-        .await
-        .expect("Failed to read session file");
-    let session_store = Box::new(JsonSessionStore::new(json!({
-        "session_data": STANDARD.encode(&bytes)
-    })));
-
-    let client = builder
-        .build(config1.to_auth_config(), Some(session_store))
-        .await
-        .expect("Failed to create client");
-
-    // Check authorization
-    let is_authorized = client
-        .is_authorized()
-        .await
-        .expect("Failed to check authorization");
-
-    if !is_authorized {
-        eprintln!("Skipping test: Client is not authorized");
-        return;
-    }
-
-    // Get first dialog
-    let mut dialogs = client
-        .iter_dialogs()
-        .await
-        .expect("Failed to get dialogs stream");
-
-    let first_dialog = match dialogs.next().await {
-        Some(Ok(dialog)) => dialog,
-        Some(Err(e)) => {
-            eprintln!("Failed to get first dialog: {}", e);
-            return;
-        }
-        None => {
-            eprintln!("No dialogs found");
-            return;
-        }
-    };
-
-    // Get first message
-    let mut messages = client
-        .iter_messages(&first_dialog.external_id)
-        .await
-        .expect("Failed to get messages stream");
-
-    let first_message = match messages.next().await {
-        Some(Ok(message)) => message,
-        Some(Err(e)) => {
-            eprintln!("Failed to get first message: {}", e);
-            return;
-        }
-        None => {
-            eprintln!("No messages found in dialog");
-            return;
-        }
-    };
-
-    // Get native message payload
-    // Note: message external_id format is "message_id" in our implementation
-    // We need to construct it properly: "chat_id:message_id"
-    let message_external_id = format!("{}:{}", first_dialog.external_id, first_message.external_id);
-    let native_message = client
-        .get_native_message(&message_external_id)
-        .await
-        .expect("Failed to get native message");
-
-    // Verify native payload structure
-    assert!(
-        native_message.payload.is_object(),
-        "Native message payload should be a JSON object"
-    );
-    println!("Native message payload: {}", native_message.payload);
-}
-
-#[tokio::test]
-async fn test_send_edit_delete_messages_with_update_stream() {
-    let configs = TestConfig::from_env();
-    if configs.is_none() {
-        eprintln!("Skipping test: TG_API_ID_1, TG_API_HASH_1, TG_API_ID_2, TG_API_HASH_2 not set");
-        return;
-    }
-
-    let (config1, config2) = configs.unwrap();
-    let builder = TelegramClientBuilder::new();
-
-    let bytes = tokio::fs::read(&config1.session_file)
-        .await
-        .expect("Failed to read session file");
-
-    // Create first client
-    let session_store1 = Box::new(JsonSessionStore::new(json!({
-        "session_data": STANDARD.encode(&bytes)
-    })));
-    let client1 = builder
-        .build(config1.to_auth_config(), Some(session_store1))
-        .await
-        .expect("Failed to create first client");
-
-    let bytes = tokio::fs::read(&config2.session_file)
-        .await
-        .expect("Failed to read session file");
-    // Create second client
-    let session_store2 = Box::new(JsonSessionStore::new(json!({
-        "session_data": STANDARD.encode(&bytes)
-    })));
-    let client2 = builder
-        .build(config2.to_auth_config(), Some(session_store2))
-        .await
-        .expect("Failed to create second client");
-
-    // Check authorization
-    let is_authorized1 = client1
-        .is_authorized()
-        .await
-        .expect("Failed to check authorization for client1");
-    let is_authorized2 = client2
-        .is_authorized()
-        .await
-        .expect("Failed to check authorization for client2");
-
-    if !is_authorized1 || !is_authorized2 {
-        eprintln!("Skipping test: One or both clients are not authorized");
-        return;
-    }
-
-    // Find the dialog between client1 and client2
-    // We need to find a user dialog (we'll use the first user dialog found)
-    let mut dialogs = client1
-        .iter_dialogs()
-        .await
-        .expect("Failed to get dialogs stream");
-
-    let mut target_chat_id: Option<String> = None;
-    while let Some(dialog_result) = dialogs.next().await {
-        let dialog = dialog_result.expect("Failed to get dialog");
-
-        // Check if this is a user dialog (not a group/channel)
-        if dialog.chat_type.as_deref() == Some("user") {
-            // Try to get the native chat to check if it matches client2
-            // For now, we'll use the first user dialog or we could check phone numbers
-            // For simplicity, let's use the first user dialog we find
-            target_chat_id = Some(dialog.external_id.clone());
-            break;
-        }
-    }
-
-    let chat_external_id = target_chat_id.unwrap_or_else(|| {
-        eprintln!("No user dialog found between clients. Please ensure client1 has a dialog with client2.");
-        return String::new();
-    });
-
-    if chat_external_id.is_empty() {
-        return;
-    }
-
-    // Start update stream on client2
-    let mut updates = client2
-        .iter_updates()
-        .await
-        .expect("Failed to get update stream");
-
-    // Send initial message from client1
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    let initial_text = format!("Test message {}", timestamp);
-    let message_external_id = client1
-        .send_message(&chat_external_id, &initial_text)
-        .await
-        .expect("Failed to send message");
-
-    println!("Sent message with external_id: {}", message_external_id);
-
-    // Wait for NewMessage update on client2, filtering out other updates
-    // Note: client2 receives the message from client1, so it should be incoming (outgoing=false)
-    // Note: chat_id may differ between client1 and client2 perspectives, so we match by text and incoming status
-    let new_msg = loop {
-        tokio::select! {
-            update_result = updates.next() => {
-                match update_result {
-                    Some(Ok(Update::NewMessage(msg))) => {
-                        // Match by text and incoming status (chat_id may differ between client perspectives)
-                        if msg.text == Some(initial_text.clone())
-                            && !msg.outgoing  // Message should be incoming for client2
-                        {
-                            println!("✓ Received NewMessage update: chat_id={}, message_id={}",
-                                msg.chat_external_id, msg.external_id);
-                            break msg;
-                        }
-                        println!("Skipping NewMessage: chat_id={}, text={:?}, outgoing={}, expected_text={:?}",
-                            msg.chat_external_id, msg.text, msg.outgoing, initial_text);
-                    }
-                    Some(Ok(other)) => {
-                        println!("Skipping update: {:?}", other);
-                    }
-                    Some(Err(e)) => {
-                        panic!("Error receiving update: {}", e);
-                    }
-                    None => {
-                        panic!("Update stream ended unexpectedly");
-                    }
-                }
-            }
-            _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {
-                panic!("Timeout waiting for NewMessage update");
-            }
-        }
-    };
-    assert_eq!(new_msg.text, Some(initial_text.clone()));
-    assert!(!new_msg.outgoing, "Message should be incoming for client2");
-
-    // Use the chat_id and message_id from client2's perspective for subsequent operations on client2
-    let client2_chat_id = new_msg.chat_external_id.clone();
-    let client2_message_id = new_msg.external_id.clone(); // Use message ID from client2's perspective
-
-    // Note: message IDs can differ between client perspectives
-    // For client1 operations, we use client1's message_external_id
-    // For client2 update matching, we use client2's message_id
-
-    // Edit the message from client1 (using client1's message_external_id)
-    let edited_text = format!("Edited message {}", timestamp);
-    client1
-        .edit_message(&chat_external_id, &message_external_id, &edited_text)
-        .await
-        .expect("Failed to edit message");
-
-    println!("Edited message to: {}", edited_text);
-
-    // Wait for MessageEdited update on client2, filtering out other updates
-    // Use client2's chat_id and message_id for matching
-    let edited_msg = loop {
-        tokio::select! {
-            update_result = updates.next() => {
-                match update_result {
-                    Some(Ok(Update::MessageEdited(msg))) => {
-                        if msg.chat_external_id == client2_chat_id && msg.external_id == client2_message_id {
-                            break msg;
-                        }
-                        println!("Skipping MessageEdited: chat_id={}, message_id={}, expected_chat_id={}, expected_message_id={}",
-                            msg.chat_external_id, msg.external_id, client2_chat_id, client2_message_id);
-                    }
-                    Some(Ok(other)) => {
-                        println!("Skipping update: {:?}", other);
-                    }
-                    Some(Err(e)) => {
-                        panic!("Error receiving update: {}", e);
-                    }
-                    None => {
-                        panic!("Update stream ended unexpectedly");
-                    }
-                }
-            }
-            _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {
-                panic!("Timeout waiting for MessageEdited update");
-            }
-        }
-    };
-    assert_eq!(edited_msg.chat_external_id, client2_chat_id);
-    assert_eq!(edited_msg.external_id, client2_message_id);
-    assert_eq!(edited_msg.text, Some(edited_text.clone()));
-    println!(
-        "✓ Received MessageEdited update: {}",
-        edited_msg.external_id
-    );
-
-    // Delete the message from client1
-    client1
-        .delete_message(&chat_external_id, &message_external_id)
-        .await
-        .expect("Failed to delete message");
-
-    println!("Deleted message");
-
-    // Wait for MessageDeleted update on client2, filtering out other updates
-    // Use client2's message_id for matching (chat_id may be "unknown" in the implementation)
-    let deleted_id = loop {
-        tokio::select! {
-            update_result = updates.next() => {
-                match update_result {
-                    Some(Ok(Update::MessageDeleted {
-                        message_external_ids: deleted_ids,
-                        chat_external_id: deleted_chat_id,
-                        ..
-                    })) => {
-                        if deleted_ids.contains(&client2_message_id) {
-                            break client2_message_id.clone();
-                        }
-                        println!("Skipping MessageDeleted: chat_id={:?}, deleted_ids={:?}, expected_message_id={}",
-                            deleted_chat_id, deleted_ids, client2_message_id);
-                    }
-                    Some(Ok(other)) => {
-                        println!("Skipping update: {:?}", other);
-                    }
-                    Some(Err(e)) => {
-                        panic!("Error receiving update: {}", e);
-                    }
-                    None => {
-                        panic!("Update stream ended unexpectedly");
-                    }
-                }
-            }
-            _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {
-                panic!("Timeout waiting for MessageDeleted update");
-            }
-        }
-    };
-    assert_eq!(
-        deleted_id, client2_message_id,
-        "Expected deleted message ID to match"
-    );
-    println!("✓ Received MessageDeleted update: {}", deleted_id);
-
-    println!("All updates received successfully!");
-}
-
-#[tokio::test]
-async fn test_get_messages_count() {
-    let configs = TestConfig::from_env();
-    if configs.is_none() {
-        eprintln!("Skipping test: TG_API_ID_1, TG_API_HASH_1, TG_API_ID_2, TG_API_HASH_2 not set");
-        return;
-    }
-
-    let (config1, _config2) = configs.unwrap();
-    let builder = TelegramClientBuilder::new();
-
-    let bytes = tokio::fs::read(&config1.session_file)
-        .await
-        .expect("Failed to read session file");
-    let session_store = Box::new(JsonSessionStore::new(json!({
-        "session_data": STANDARD.encode(&bytes)
-    })));
-    let client = builder
-        .build(config1.to_auth_config(), Some(session_store))
-        .await
-        .expect("Failed to create client");
-
-    // Check authorization
-    let is_authorized = client
-        .is_authorized()
-        .await
-        .expect("Failed to check authorization");
-
-    if !is_authorized {
-        eprintln!("Skipping test: Client is not authorized");
-        return;
-    }
-
-    // Get the user's own ID to find Saved Messages chat
-    let native_client = client.get_native_client().await;
-    let client_lock = native_client.lock().await;
-    let me = client_lock.get_me().await.expect("Failed to get user info");
-    let user_id = me.raw.id();
-    drop(client_lock);
-
-    // Find Saved Messages chat (chat where chat ID equals user ID)
-    let mut dialogs = client
-        .iter_dialogs()
-        .await
-        .expect("Failed to get dialogs stream");
-
-    let saved_messages_chat_id = loop {
-        match dialogs.next().await {
-            Some(Ok(dialog)) => {
-                // Check if this is the Saved Messages chat (chat ID matches user ID)
-                if dialog.external_id == user_id.to_string() {
-                    break dialog.external_id;
-                }
-            }
+        let first_dialog = match dialogs.next().await {
+            Some(Ok(dialog)) => dialog,
             Some(Err(e)) => {
-                panic!("Failed to get dialog: {}", e);
+                panic!("Failed to get first dialog: {}", e);
             }
             None => {
-                panic!("Saved Messages chat not found. User ID: {}", user_id);
+                panic!("No dialogs found");
+            }
+        };
+
+        // Get native chat payload
+        let native_chat = client
+            .get_native_chat(&first_dialog.external_id)
+            .await
+            .expect("Failed to get native chat");
+
+        // Verify native payload structure
+        assert!(
+            native_chat.payload.is_object(),
+            "Native chat payload should be a JSON object"
+        );
+        println!("Native chat payload: {}", native_chat.payload);
+    })
+    .await
+    .expect("Test timed out");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_native_message_access() {
+    tokio::time::timeout(DEFAULT_TIMEOUT, async {
+        let configs = TestConfig::from_env();
+
+        if configs.is_none() {
+            println!("Skipping test: Environment variables not set");
+            return;
+        }
+
+        let (config1, _config2) = configs.unwrap();
+        let builder = TelegramClientBuilder::new();
+
+        // Create first client
+        let client = builder
+            .build(config1.to_auth_config(), config1.to_session_config())
+            .await
+            .expect("Failed to create first client");
+
+        // Check authorization
+        let is_authorized = client
+            .is_authorized()
+            .await
+            .expect("Failed to check authorization");
+
+        if !is_authorized {
+            panic!("Client is not authorized");
+        }
+
+        // Get first dialog
+        let mut dialogs = client
+            .iter_dialogs()
+            .await
+            .expect("Failed to get dialogs stream");
+
+        let first_dialog = match dialogs.next().await {
+            Some(Ok(dialog)) => dialog,
+            Some(Err(e)) => {
+                panic!("Failed to get first dialog: {}", e);
+            }
+            None => {
+                panic!("No dialogs found");
+            }
+        };
+
+        // Get first message
+        let mut messages = client
+            .iter_messages(&first_dialog.external_id)
+            .await
+            .expect("Failed to get messages stream");
+
+        let first_message = match messages.next().await {
+            Some(Ok(message)) => message,
+            Some(Err(e)) => {
+                panic!("Failed to get first message: {}", e);
+            }
+            None => {
+                panic!("No messages found in dialog");
+            }
+        };
+
+        // Get native message payload
+        // Note: message external_id format is "message_id" in our implementation
+        // We need to construct it properly: "chat_id:message_id"
+        let message_external_id =
+            format!("{}:{}", first_dialog.external_id, first_message.external_id);
+        let native_message = client
+            .get_native_message(&message_external_id)
+            .await
+            .expect("Failed to get native message");
+
+        // Verify native payload structure
+        assert!(
+            native_message.payload.is_object(),
+            "Native message payload should be a JSON object"
+        );
+        println!("Native message payload: {}", native_message.payload);
+    })
+    .await
+    .expect("Test timed out");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_send_edit_delete_messages_with_update_stream() {
+    tokio::time::timeout(EXTENDED_TIMEOUT, async {
+        let configs = TestConfig::from_env();
+
+        if configs.is_none() {
+            println!("Skipping test: Environment variables not set");
+            return;
+        }
+
+        let (config1, config2) = configs.unwrap();
+        let builder = TelegramClientBuilder::new();
+
+        // Create first client
+        let client1 = builder
+            .build(config1.to_auth_config(), config1.to_session_config())
+            .await
+            .expect("Failed to create first client");
+
+        // Create second client
+        let client2 = builder
+            .build(config2.to_auth_config(), config2.to_session_config())
+            .await
+            .expect("Failed to create second client");
+
+        // Check authorization
+        let is_authorized1 = client1
+            .is_authorized()
+            .await
+            .expect("Failed to check authorization for client1");
+        let is_authorized2 = client2
+            .is_authorized()
+            .await
+            .expect("Failed to check authorization for client2");
+
+        if !is_authorized1 || !is_authorized2 {
+            panic!("One or both clients are not authorized");
+        }
+
+        // Get client2's user ID to find the correct dialog
+        let client2_native = client2.get_native_client().await;
+        let client2_lock = client2_native.lock().await;
+        let client2_me = client2_lock.get_me().await.expect("Failed to get client2 user info");
+        let client2_user_id = client2_me.raw.id().to_string();
+        drop(client2_lock);
+        println!("Client2 user ID: {}", client2_user_id);
+
+        // Find the dialog between client1 and client2 using client2's user ID
+        let mut dialogs = client1
+            .iter_dialogs()
+            .await
+            .expect("Failed to get dialogs stream");
+
+        let mut target_chat_id: Option<String> = None;
+        while let Some(dialog_result) = dialogs.next().await {
+            let dialog = dialog_result.expect("Failed to get dialog");
+
+            // Check if this is a user dialog matching client2's user ID
+            if dialog.chat_type.as_deref() == Some("user") && dialog.external_id == client2_user_id {
+                println!("Found dialog with client2: {:?}", dialog);
+                target_chat_id = Some(dialog.external_id.clone());
+                break;
             }
         }
-    };
 
-    println!("Found Saved Messages chat: {}", saved_messages_chat_id);
+        let chat_external_id = target_chat_id.unwrap_or_else(|| {
+            panic!("No dialog found between client1 and client2. Please ensure client1 has a dialog with client2 (user ID: {}).", client2_user_id);
+        });
 
-    // Get initial message count
-    let initial_count = client
-        .get_messages_count(&saved_messages_chat_id)
-        .await
-        .expect("Failed to get initial message count");
+        // Start update stream on client2
+        let mut updates = client2
+            .iter_updates()
+            .await
+            .expect("Failed to get update stream");
 
-    println!("Initial message count: {}", initial_count);
+        // Send initial message from client1
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let initial_text = format!("Test message {}", timestamp);
+        let message_external_id = client1
+            .send_message(&chat_external_id, &initial_text)
+            .await
+            .expect("Failed to send message");
 
-    // Send a message to Saved Messages
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    let test_message = format!("Test message for count {}", timestamp);
-    let _message_external_id = client
-        .send_message(&saved_messages_chat_id, &test_message)
-        .await
-        .expect("Failed to send message");
+        println!("Sent message with external_id: {}", message_external_id);
 
-    println!("Sent test message: {}", test_message);
+        // Wait for NewMessage update on client2, filtering out other updates
+        // Note: client2 receives the message from client1, so it should be incoming (outgoing=false)
+        // Note: chat_id may differ between client1 and client2 perspectives, so we match by text and incoming status
+        let new_msg = loop {
+            tokio::select! {
+                update_result = updates.next() => {
+                    match update_result {
+                        Some(Ok(Update::NewMessage(msg))) => {
+                            // Match by text and incoming status (chat_id may differ between client perspectives)
+                            if msg.text == Some(initial_text.clone())
+                                && !msg.outgoing  // Message should be incoming for client2
+                            {
+                                println!("✓ Received NewMessage update: chat_id={}, message_id={}",
+                                    msg.chat_external_id, msg.external_id);
+                                break msg;
+                            }
+                            println!("Skipping NewMessage: chat_id={}, text={:?}, outgoing={}, expected_text={:?}",
+                                msg.chat_external_id, msg.text, msg.outgoing, initial_text);
+                        }
+                        Some(Ok(other)) => {
+                            println!("Skipping update: {:?}", other);
+                        }
+                        Some(Err(e)) => {
+                            panic!("Error receiving update: {}", e);
+                        }
+                        None => {
+                            panic!("Update stream ended unexpectedly");
+                        }
+                    }
+                }
+                _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {
+                    panic!("Timeout waiting for NewMessage update");
+                }
+            }
+        };
+        assert_eq!(new_msg.text, Some(initial_text.clone()));
+        assert!(!new_msg.outgoing, "Message should be incoming for client2");
 
-    // Wait a bit for the message to be processed
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        // Use the chat_id and message_id from client2's perspective for subsequent operations on client2
+        let client2_chat_id = new_msg.chat_external_id.clone();
+        let client2_message_id = new_msg.external_id.clone(); // Use message ID from client2's perspective
 
-    // Get message count again
-    let new_count = client
-        .get_messages_count(&saved_messages_chat_id)
-        .await
-        .expect("Failed to get new message count");
+        // Note: message IDs can differ between client perspectives
+        // For client1 operations, we use client1's message_external_id
+        // For client2 update matching, we use client2's message_id
 
-    println!("New message count: {}", new_count);
+        // Edit the message from client1 (using client1's message_external_id)
+        let edited_text = format!("Edited message {}", timestamp);
+        client1
+            .edit_message(&chat_external_id, &message_external_id, &edited_text)
+            .await
+            .expect("Failed to edit message");
 
-    // Verify the count increased by 1
-    assert_eq!(
-        new_count,
-        initial_count + 1,
-        "Message count should increase by 1 after sending a message. Initial: {}, New: {}",
-        initial_count,
-        new_count
-    );
+        println!("Edited message to: {}", edited_text);
 
-    println!("✓ Message count test passed!");
+        // Wait for MessageEdited update on client2, filtering out other updates
+        // Use client2's chat_id and message_id for matching
+        let edited_msg = loop {
+            tokio::select! {
+                update_result = updates.next() => {
+                    match update_result {
+                        Some(Ok(Update::MessageEdited(msg))) => {
+                            if msg.chat_external_id == client2_chat_id && msg.external_id == client2_message_id {
+                                break msg;
+                            }
+                            println!("Skipping MessageEdited: chat_id={}, message_id={}, expected_chat_id={}, expected_message_id={}",
+                                msg.chat_external_id, msg.external_id, client2_chat_id, client2_message_id);
+                        }
+                        Some(Ok(other)) => {
+                            println!("Skipping update: {:?}", other);
+                        }
+                        Some(Err(e)) => {
+                            panic!("Error receiving update: {}", e);
+                        }
+                        None => {
+                            panic!("Update stream ended unexpectedly");
+                        }
+                    }
+                }
+                _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {
+                    panic!("Timeout waiting for MessageEdited update");
+                }
+            }
+        };
+        assert_eq!(edited_msg.chat_external_id, client2_chat_id);
+        assert_eq!(edited_msg.external_id, client2_message_id);
+        assert_eq!(edited_msg.text, Some(edited_text.clone()));
+        println!(
+            "✓ Received MessageEdited update: {}",
+            edited_msg.external_id
+        );
+
+        // Delete the message from client1
+        client1
+            .delete_message(&chat_external_id, &message_external_id)
+            .await
+            .expect("Failed to delete message");
+
+        println!("Deleted message");
+
+        // Wait for MessageDeleted update on client2, filtering out other updates
+        // Use client2's message_id for matching (chat_id may be "unknown" in the implementation)
+        let deleted_id = loop {
+            tokio::select! {
+                update_result = updates.next() => {
+                    match update_result {
+                        Some(Ok(Update::MessageDeleted {
+                            message_external_ids: deleted_ids,
+                            chat_external_id: deleted_chat_id,
+                            ..
+                        })) => {
+                            if deleted_ids.contains(&client2_message_id) {
+                                break client2_message_id.clone();
+                            }
+                            println!("Skipping MessageDeleted: chat_id={:?}, deleted_ids={:?}, expected_message_id={}",
+                                deleted_chat_id, deleted_ids, client2_message_id);
+                        }
+                        Some(Ok(other)) => {
+                            println!("Skipping update: {:?}", other);
+                        }
+                        Some(Err(e)) => {
+                            panic!("Error receiving update: {}", e);
+                        }
+                        None => {
+                            panic!("Update stream ended unexpectedly");
+                        }
+                    }
+                }
+                _ = tokio::time::sleep(tokio::time::Duration::from_secs(10)) => {
+                    panic!("Timeout waiting for MessageDeleted update");
+                }
+            }
+        };
+        assert_eq!(
+            deleted_id, client2_message_id,
+            "Expected deleted message ID to match"
+        );
+        println!("✓ Received MessageDeleted update: {}", deleted_id);
+
+        println!("All updates received successfully!");
+    })
+    .await
+    .expect("Test timed out");
+}
+
+#[tokio::test]
+#[serial]
+async fn test_get_messages_count() {
+    tokio::time::timeout(DEFAULT_TIMEOUT, async {
+        let configs = TestConfig::from_env();
+
+        if configs.is_none() {
+            println!("Skipping test: Environment variables not set");
+            return;
+        }
+
+        let (config1, _config2) = configs.unwrap();
+        let builder = TelegramClientBuilder::new();
+
+        // Create first client
+        let client = builder
+            .build(config1.to_auth_config(), config1.to_session_config())
+            .await
+            .expect("Failed to create first client");
+
+        // Check authorization
+        let is_authorized = client
+            .is_authorized()
+            .await
+            .expect("Failed to check authorization");
+
+        if !is_authorized {
+            panic!("Client is not authorized");
+        }
+
+        // Get the user's own ID to find Saved Messages chat
+        let native_client = client.get_native_client().await;
+        let client_lock = native_client.lock().await;
+        let me = client_lock.get_me().await.expect("Failed to get user info");
+        let user_id = me.raw.id();
+        drop(client_lock);
+
+        // Find Saved Messages chat (chat where chat ID equals user ID)
+        let mut dialogs = client
+            .iter_dialogs()
+            .await
+            .expect("Failed to get dialogs stream");
+
+        let saved_messages_chat_id = loop {
+            match dialogs.next().await {
+                Some(Ok(dialog)) => {
+                    // Check if this is the Saved Messages chat (chat ID matches user ID)
+                    if dialog.external_id == user_id.to_string() {
+                        break dialog.external_id;
+                    }
+                }
+                Some(Err(e)) => {
+                    panic!("Failed to get dialog: {}", e);
+                }
+                None => {
+                    panic!("Saved Messages chat not found. User ID: {}", user_id);
+                }
+            }
+        };
+
+        println!("Found Saved Messages chat: {}", saved_messages_chat_id);
+
+        // Get initial message count
+        let initial_count = client
+            .get_messages_count(&saved_messages_chat_id)
+            .await
+            .expect("Failed to get initial message count");
+
+        println!("Initial message count: {}", initial_count);
+
+        // Send a message to Saved Messages
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let test_message = format!("Test message for count {}", timestamp);
+        let _message_external_id = client
+            .send_message(&saved_messages_chat_id, &test_message)
+            .await
+            .expect("Failed to send message");
+
+        println!("Sent test message: {}", test_message);
+
+        // Wait a bit for the message to be processed
+        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+        // Get message count again
+        let new_count = client
+            .get_messages_count(&saved_messages_chat_id)
+            .await
+            .expect("Failed to get new message count");
+
+        println!("New message count: {}", new_count);
+
+        // Verify the count increased by 1
+        let delta = new_count.saturating_sub(initial_count);
+        println!(
+            "Saved Messages count delta after sending one test message: {} (initial={}, new={})",
+            delta, initial_count, new_count
+        );
+        assert!(
+            new_count >= initial_count + 1,
+            "Expected Saved Messages count to increase by at least 1 after sending a test message"
+        );
+
+        println!("✓ Message count test passed!");
+    })
+    .await
+    .expect("Test timed out");
 }


### PR DESCRIPTION
## Summary by Sourcery

Stabilize and serialize Telegram messenger integration tests while fixing internal client dialog access to avoid deadlocks, and enable Rust compilation caching in the Nix development environment.

Enhancements:
- Refactor Telegram client dialog lookup to use a reusable helper that operates with an existing locked client, preventing potential deadlocks during operations such as iterating or sending messages.
- Adjust Telegram client builder to start the underlying connection pool runner task automatically on construction.

Build:
- Integrate sccache into the Nix flake dev environment and shells, configuring it as the RUSTC_WRAPPER to speed up Rust builds.

Tests:
- Rework Telegram integration tests to use JsonSessionStore directly, enforce serial execution, add explicit timeouts, and replace soft skips with hard failures to make them more reliable and deterministic.

Chores:
- Remove unused DIRTY_TOKEN_ISSUER constant from the sdb_server binary.