### PR TITLE
Finish basic reply storing/display

### DIFF
--- a/bins/convex-backend/convex/model/messages.ts
+++ b/bins/convex-backend/convex/model/messages.ts
@@ -34,7 +34,6 @@ const messageFields = v.object({
   mediaExternalId: v.optional(v.string()),
   mediaKind: v.optional(mediaKind),
   replyToMessageId: v.optional(v.string()),
-  replyToText: v.optional(v.string()),
   forwardedFrom: v.optional(forwardedFromValidator),
   reactions: v.optional(v.array(reactionValidator)),
 });
@@ -154,24 +153,7 @@ export const listByChat = humanQuery({
 /** Upsert a message. Human-only (workers use workerUpsertMessage).
  *  Auto-creates media records respecting per-chat/client media settings. */
 export const upsert = humanMutation({
-  args: {
-    messageId: v.string(),
-    externalId: v.string(),
-    userId: v.string(),
-    clientId: v.id("clients"),
-    chatId: v.string(),
-    senderId: v.string(),
-    text: v.optional(v.string()),
-    outgoing: v.boolean(),
-    deleted: v.boolean(),
-    timestamp: v.number(),
-    mediaExternalId: v.optional(v.string()),
-    mediaKind: v.optional(mediaKind),
-    replyToMessageId: v.optional(v.string()),
-    replyToText: v.optional(v.string()),
-    forwardedFrom: v.optional(forwardedFromValidator),
-    reactions: v.optional(v.array(reactionValidator)),
-  },
+  args: messageFields,
   returns: v.null(),
   handler: async (ctx, args) => {
     if (ctx.caller.tokenIdentifier !== args.userId) {
@@ -192,7 +174,6 @@ export const upsert = humanMutation({
         mediaExternalId: args.mediaExternalId,
         mediaKind: args.mediaKind,
         replyToMessageId: args.replyToMessageId,
-        replyToText: args.replyToText,
         forwardedFrom: args.forwardedFrom,
         reactions: args.reactions,
       });

--- a/bins/convex-backend/convex/model/messages.ts
+++ b/bins/convex-backend/convex/model/messages.ts
@@ -291,20 +291,7 @@ export const markDeleted = humanMutation({
 
 /** Upsert a message. Worker-only. */
 export const workerUpsertMessage = workerMutation({
-  args: {
-    messageId: v.string(),
-    externalId: v.string(),
-    userId: v.string(),
-    clientId: v.id("clients"),
-    chatId: v.string(),
-    senderId: v.string(),
-    text: v.optional(v.string()),
-    outgoing: v.boolean(),
-    deleted: v.boolean(),
-    timestamp: v.number(),
-    mediaExternalId: v.optional(v.string()),
-    mediaKind: v.optional(mediaKind),
-  },
+  args: messageFields,
   returns: v.null(),
   handler: async (ctx, args) => {
     const existing = await ctx.db

--- a/bins/convex-backend/convex/testHelpers.ts
+++ b/bins/convex-backend/convex/testHelpers.ts
@@ -101,7 +101,6 @@ export const seedMessage = workerMutation({
     mediaExternalId: v.optional(v.string()),
     mediaKind: v.optional(mediaKind),
     replyToMessageId: v.optional(v.string()),
-    replyToText: v.optional(v.string()),
     forwardedFrom: v.optional(forwardedFromValidator),
     reactions: v.optional(v.array(reactionValidator)),
   },

--- a/bins/crm-chat-web/src/components/chats-page.tsx
+++ b/bins/crm-chat-web/src/components/chats-page.tsx
@@ -8,84 +8,80 @@ import { ChatList } from "./chat-list";
 import { MessageList, makeScrollRequest } from "./message-list";
 
 export function ChatsPage(): React.ReactNode {
-  const params = useParams({ strict: false });
-  const search = useSearch({ strict: false }) as { messageId?: string };
-  const navigate = useNavigate();
-  const selectedChatId = params.chatId ?? null;
+	const params = useParams({ strict: false });
+	const search = useSearch({ strict: false }) as { messageId?: string };
+	const navigate = useNavigate();
+	const selectedChatId = params.chatId ?? null;
 
-  // Convert URL search param into a scroll request only when it changes.
-  const scrollToRef = useRef<ReturnType<typeof makeScrollRequest> | undefined>(
-    undefined
-  );
-  const prevMessageIdRef = useRef(search?.messageId);
-  if (prevMessageIdRef.current !== search?.messageId) {
-    prevMessageIdRef.current = search?.messageId;
-    scrollToRef.current = search?.messageId
-      ? makeScrollRequest(search.messageId)
-      : undefined;
-  }
-  const scrollTo = scrollToRef.current;
+	// Convert URL search param into a scroll request only when it changes.
+	const prevMessageIdRef = useRef(search?.messageId);
+	if (prevMessageIdRef.current !== search?.messageId) {
+		prevMessageIdRef.current = search?.messageId;
+	}
+	const scrollTo = search?.messageId
+		? makeScrollRequest(search.messageId)
+		: undefined;
 
-  const clients = useQuery(api.model.clients.list);
-  const chats = useQuery(api.model.chats.list);
+	const clients = useQuery(api.model.clients.list);
+	const chats = useQuery(api.model.chats.list);
 
-  if (import.meta.env.DEV) {
-    console.log({ clients });
-    console.log({ chats });
-  }
+	if (import.meta.env.DEV) {
+		console.log({ clients });
+		console.log({ chats });
+	}
 
-  const handleSelectChat = (chatId: string | null): void => {
-    if (chatId) {
-      navigate({ to: "/chats/$chatId", params: { chatId } });
-    } else {
-      navigate({ to: "/chats" });
-    }
-  };
+	const handleSelectChat = (chatId: string | null): void => {
+		if (chatId) {
+			navigate({ to: "/chats/$chatId", params: { chatId } });
+		} else {
+			navigate({ to: "/chats" });
+		}
+	};
 
-  const handleBack = (): void => {
-    navigate({ to: "/chats" });
-  };
+	const handleBack = (): void => {
+		navigate({ to: "/chats" });
+	};
 
-  return (
-    <div className="flex h-full">
-      <div
-        className={cn(
-          "h-full w-full shrink-0 border-border/50 border-r md:w-80 lg:w-96",
-          selectedChatId ? "hidden md:block" : "block"
-        )}
-      >
-        <ChatList
-          onSelectChat={handleSelectChat}
-          selectedChatId={selectedChatId}
-        />
-      </div>
+	return (
+		<div className="flex h-full">
+			<div
+				className={cn(
+					"h-full w-full shrink-0 border-border/50 border-r md:w-80 lg:w-96",
+					selectedChatId ? "hidden md:block" : "block",
+				)}
+			>
+				<ChatList
+					onSelectChat={handleSelectChat}
+					selectedChatId={selectedChatId}
+				/>
+			</div>
 
-      <div
-        className={cn(
-          "h-full flex-1",
-          selectedChatId ? "block" : "hidden md:block"
-        )}
-      >
-        {selectedChatId ? (
-          <MessageList
-            chatId={selectedChatId}
-            onBack={handleBack}
-            scrollTo={scrollTo}
-          />
-        ) : (
-          <div className="flex h-full flex-col items-center justify-center p-4 text-center">
-            <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/8">
-              <MessageSquare className="h-7 w-7 text-primary/40" />
-            </div>
-            <h3 className="mt-5 font-display font-medium text-base">
-              Select a chat
-            </h3>
-            <p className="mt-1.5 max-w-xs text-muted-foreground/70 text-sm">
-              Choose a conversation from the list to view messages
-            </p>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+			<div
+				className={cn(
+					"h-full flex-1",
+					selectedChatId ? "block" : "hidden md:block",
+				)}
+			>
+				{selectedChatId ? (
+					<MessageList
+						chatId={selectedChatId}
+						onBack={handleBack}
+						scrollTo={scrollTo}
+					/>
+				) : (
+					<div className="flex h-full flex-col items-center justify-center p-4 text-center">
+						<div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/8">
+							<MessageSquare className="h-7 w-7 text-primary/40" />
+						</div>
+						<h3 className="mt-5 font-display font-medium text-base">
+							Select a chat
+						</h3>
+						<p className="mt-1.5 max-w-xs text-muted-foreground/70 text-sm">
+							Choose a conversation from the list to view messages
+						</p>
+					</div>
+				)}
+			</div>
+		</div>
+	);
 }

--- a/bins/crm-chat-web/src/components/chats-page.tsx
+++ b/bins/crm-chat-web/src/components/chats-page.tsx
@@ -1,17 +1,30 @@
 import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useQuery } from "convex-helpers/react/cache";
 import { MessageSquare } from "lucide-react";
+import { useRef } from "react";
 import { api } from "@/lib/convex";
 import { cn } from "@/lib/utils";
 import { ChatList } from "./chat-list";
-import { MessageList } from "./message-list";
+import { MessageList, makeScrollRequest } from "./message-list";
 
 export function ChatsPage(): React.ReactNode {
   const params = useParams({ strict: false });
   const search = useSearch({ strict: false }) as { messageId?: string };
   const navigate = useNavigate();
   const selectedChatId = params.chatId ?? null;
-  const targetMessageId = search?.messageId;
+
+  // Convert URL search param into a scroll request only when it changes.
+  const scrollToRef = useRef<ReturnType<typeof makeScrollRequest> | undefined>(
+    undefined
+  );
+  const prevMessageIdRef = useRef(search?.messageId);
+  if (prevMessageIdRef.current !== search?.messageId) {
+    prevMessageIdRef.current = search?.messageId;
+    scrollToRef.current = search?.messageId
+      ? makeScrollRequest(search.messageId)
+      : undefined;
+  }
+  const scrollTo = scrollToRef.current;
 
   const clients = useQuery(api.model.clients.list);
   const chats = useQuery(api.model.chats.list);
@@ -57,7 +70,7 @@ export function ChatsPage(): React.ReactNode {
           <MessageList
             chatId={selectedChatId}
             onBack={handleBack}
-            targetMessageId={targetMessageId}
+            scrollTo={scrollTo}
           />
         ) : (
           <div className="flex h-full flex-col items-center justify-center p-4 text-center">

--- a/bins/crm-chat-web/src/components/message-list.tsx
+++ b/bins/crm-chat-web/src/components/message-list.tsx
@@ -305,6 +305,7 @@ function MessageListItem({
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function makeScrollRequest(messageId: string) {
   return /* scrollTo: */ { messageId, _aux: Date.now() };
 }
@@ -329,6 +330,7 @@ export function MessageList({
   const orderedMessages = [...results].reverse() as Doc<"messages">[];
 
   const msgContainerRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line react-hooks/incompatible-library
   const virtualizer = useVirtualizer({
     count: orderedMessages.length,
     getScrollElement: () => msgContainerRef.current,

--- a/bins/crm-chat-web/src/components/message-list.tsx
+++ b/bins/crm-chat-web/src/components/message-list.tsx
@@ -1,69 +1,22 @@
 "use no memo";
 
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { useNavigate } from "@tanstack/react-router";
+import {
+  elementScroll,
+  useVirtualizer,
+  type VirtualizerOptions,
+} from "@tanstack/react-virtual";
 import { usePaginatedQuery, useQuery } from "convex/react";
 import { ArrowLeft, Ban, Forward, Loader2, Reply } from "lucide-react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { api } from "@/lib/convex";
+import { api, type Doc } from "@/lib/convex";
+import { displayChatName, displayClientName } from "@/utils/display";
+import { formatDateHeader, formatMessageTime } from "@/utils/format";
 import { cn } from "../lib/utils";
 import { type MediaInfo, MediaRenderer } from "./media-renderer";
 import { Button } from "./ui/button";
 
 const PAGE_SIZE = 8000;
-
-interface MessageListProps {
-  chatId: string;
-  onBack?: () => void;
-  targetMessageId?: string;
-}
-
-function formatMessageTime(ts: number): string {
-  const date = new Date(ts);
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-}
-
-function formatDateHeader(ts: number): string {
-  const date = new Date(ts);
-  const now = new Date();
-  const isToday = date.toDateString() === now.toDateString();
-
-  if (isToday) {
-    return "Today";
-  }
-
-  const yesterday = new Date(now);
-  yesterday.setDate(yesterday.getDate() - 1);
-  if (date.toDateString() === yesterday.toDateString()) {
-    return "Yesterday";
-  }
-
-  return date.toLocaleDateString([], {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-  });
-}
-
-function getChatDisplayName(
-  chat: { pinnedName?: string; chatId: string } | undefined
-): string {
-  if (!chat) {
-    return "Chat";
-  }
-  if (chat.pinnedName) {
-    return chat.pinnedName;
-  }
-  return `Chat ${chat.chatId.slice(0, 8)}`;
-}
-
-function getClientDisplayName(
-  client: { kind: string; telegramId: string } | undefined
-): string {
-  if (!client) {
-    return "";
-  }
-  return `${client.kind} • ${client.telegramId}`;
-}
 
 interface ReactionDoc {
   count: number;
@@ -71,30 +24,9 @@ interface ReactionDoc {
   recent: Array<{ userId: string }>;
 }
 
-interface ForwardedFromDoc {
-  date?: number;
-  senderName: string;
-}
-
-interface MessageDoc {
-  _id: string;
-  chatId: string;
-  deleted: boolean;
-  forwardedFrom?: ForwardedFromDoc;
-  mediaExternalId?: string;
-  mediaKind?: string;
-  messageId: string;
-  outgoing: boolean;
-  reactions?: ReactionDoc[];
-  replyToMessageId?: string;
-  replyToText?: string;
-  text?: string;
-  timestamp: number;
-}
-
 function shouldShowDateHeader(
-  message: MessageDoc,
-  prevMessage: MessageDoc | undefined
+  message: Doc<"messages">,
+  prevMessage: Doc<"messages"> | undefined
 ): boolean {
   if (!prevMessage) {
     return true;
@@ -105,6 +37,95 @@ function shouldShowDateHeader(
 
   return messageDate !== prevDate;
 }
+
+function truncateText(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, maxLength)}…`;
+}
+
+function getHighlightClasses(variant: number): {
+  outline: string;
+  bg: string;
+} {
+  const isEven = variant % 2 === 0;
+  return {
+    outline: isEven
+      ? "animate-highlight-outline-a"
+      : "animate-highlight-outline-b",
+    bg: isEven ? "animate-highlight-bg-a" : "animate-highlight-bg-b",
+  };
+}
+
+function getScrollAlign(
+  index: number,
+  scrollEl: HTMLElement | null,
+  virtualizer: ReturnType<typeof useVirtualizer<HTMLDivElement, Element>>
+): "start" | "center" | "end" | null {
+  const item = virtualizer.getVirtualItems().find((vi) => vi.index === index);
+  if (!(scrollEl && item)) {
+    return "center";
+  }
+
+  const viewTop = scrollEl.scrollTop;
+  const viewHeight = scrollEl.clientHeight;
+  const margin = viewHeight * 0.05;
+  const boxTop = viewTop + margin;
+  const boxBottom = viewTop + viewHeight - margin;
+
+  if (item.start >= boxTop && item.end <= boxBottom) {
+    return null;
+  }
+  if (item.start >= viewTop && item.end <= viewTop + viewHeight) {
+    return item.start < boxTop ? "start" : "end";
+  }
+  return "center";
+}
+const scrollBehavior = ((): VirtualizerOptions<
+  HTMLDivElement,
+  Element
+>["scrollToFn"] => {
+  let rafId: number | null = null;
+  return (offset, options, instance) => {
+    const el = instance.scrollElement;
+    if (!el) {
+      return;
+    }
+
+    if (options.behavior !== "smooth") {
+      elementScroll(offset, options, instance);
+      return;
+    }
+
+    const startPos = el.scrollTop;
+    const distance = offset - startPos;
+    if (Math.abs(distance) < 1) {
+      return;
+    }
+
+    const duration = 50;
+    let startTime = -1;
+
+    const step = (now: number): void => {
+      if (startTime < 0) {
+        startTime = now;
+      }
+      const elapsed = now - startTime;
+      const t = Math.min(elapsed / duration, 1);
+      const eased = t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2;
+      el.scrollTop = startPos + distance * eased;
+      if (t < 1) {
+        rafId = requestAnimationFrame(step);
+      }
+    };
+
+    if (rafId) {
+      cancelAnimationFrame(rafId);
+    }
+    rafId = requestAnimationFrame(step);
+  };
+})();
 
 function ReactionBadges({
   hasMedia,
@@ -142,131 +163,162 @@ function ReactionBadges({
   );
 }
 
-function truncateText(text: string, maxLength: number): string {
-  if (text.length <= maxLength) {
-    return text;
-  }
-  return `${text.slice(0, maxLength)}…`;
+function ReplyPreview({
+  hasMedia,
+  isOutgoing,
+  onClick,
+  text,
+}: {
+  hasMedia: boolean;
+  isOutgoing: boolean;
+  onClick?: () => void;
+  text?: string;
+}): React.ReactNode {
+  return (
+    <button
+      className={cn(
+        "mb-1 w-full rounded-md border-l-2 px-2 py-1 text-left text-[11px]",
+        hasMedia ? "mx-1.5 mt-1" : "",
+        isOutgoing
+          ? "border-primary-foreground/40 bg-primary-foreground/10 text-primary-foreground/70"
+          : "border-muted-foreground/40 bg-muted/50 text-muted-foreground"
+      )}
+      data-testid="reply-preview"
+      onClick={onClick}
+      type="button"
+    >
+      <div className="flex items-center gap-1">
+        <Reply className="h-3 w-3 shrink-0" />
+        <span className="truncate">
+          {text ? truncateText(text, 100) : "Reply"}
+        </span>
+      </div>
+    </button>
+  );
 }
 
-function MessageBubble({
+function MessageListItem({
   message,
   media,
-  highlighted,
+  highlight,
+  replyText,
+  onReplyClick,
 }: {
-  message: MessageDoc;
+  message: Doc<"messages">;
   media?: MediaInfo;
-  highlighted?: boolean;
+  highlight?: { method: "flash"; variant: number };
+  replyText?: string;
+  onReplyClick?: () => void;
 }): React.ReactNode {
   const isOutgoing = message.outgoing;
   const isDeleted = message.deleted;
   const hasMedia = media !== undefined;
+  const hlClasses = highlight ? getHighlightClasses(highlight.variant) : null;
 
   return (
-    <div className={cn("flex", isOutgoing ? "justify-end" : "justify-start")}>
-      <div
-        className={cn(
-          "max-w-[70%] overflow-hidden rounded-2xl shadow-sm transition-colors duration-700",
-          hasMedia ? "p-1" : "px-3.5 py-2",
-          isDeleted && "opacity-50",
-          highlighted &&
-            "ring-2 ring-primary ring-offset-2 ring-offset-background",
-          isOutgoing
-            ? "rounded-br-md bg-primary text-primary-foreground"
-            : "rounded-bl-md bg-card ring-1 ring-border/40"
-        )}
-      >
-        {message.forwardedFrom && (
-          <div
-            className={cn(
-              "mb-1 flex items-center gap-1 text-[11px]",
-              hasMedia ? "px-2.5 pt-1" : "",
-              isOutgoing
-                ? "text-primary-foreground/70"
-                : "text-muted-foreground"
-            )}
-            data-testid="forwarded-from"
-          >
-            <Forward className="h-3 w-3" />
-            <span className="italic">
-              Forwarded from {message.forwardedFrom.senderName}
-            </span>
-          </div>
-        )}
-
-        {message.replyToText && (
-          <div
-            className={cn(
-              "mb-1 rounded-md border-l-2 px-2 py-1 text-[11px]",
-              hasMedia ? "mx-1.5 mt-1" : "",
-              isOutgoing
-                ? "border-primary-foreground/40 bg-primary-foreground/10 text-primary-foreground/70"
-                : "border-muted-foreground/40 bg-muted/50 text-muted-foreground"
-            )}
-            data-testid="reply-preview"
-          >
-            <div className="flex items-center gap-1">
-              <Reply className="h-3 w-3 shrink-0" />
-              <span className="truncate">
-                {truncateText(message.replyToText, 100)}
-              </span>
-            </div>
-          </div>
-        )}
-
-        {isDeleted && (
-          <div className="mb-1 flex items-center gap-1 px-2.5 pt-1 text-[11px] opacity-70">
-            <Ban className="h-3 w-3" />
-            <span className="italic">Deleted</span>
-          </div>
-        )}
-
-        {hasMedia && <MediaRenderer isOutgoing={isOutgoing} media={media} />}
-
-        {message.text && (
-          <p
-            className={cn(
-              "whitespace-pre-wrap break-all text-[13px] leading-relaxed",
-              hasMedia && "px-2.5 pt-1"
-            )}
-          >
-            {message.text}
-          </p>
-        )}
-
-        {!(message.text || hasMedia) && (
-          <p className="text-[13px] italic opacity-50">[Empty message]</p>
-        )}
-
+    <div className={cn("px-4 py-1", hlClasses?.bg)}>
+      <div className={cn("flex", isOutgoing ? "justify-end" : "justify-start")}>
         <div
           className={cn(
-            "mt-0.5 text-right text-[10px]",
-            hasMedia && "px-2.5 pb-1",
+            "max-w-[70%] overflow-hidden rounded-2xl shadow-sm",
+            hasMedia ? "p-1" : "px-3.5 py-2",
+            isDeleted && "opacity-50",
+            hlClasses?.outline,
             isOutgoing
-              ? "text-primary-foreground/50"
-              : "text-muted-foreground/60"
+              ? "rounded-br-md bg-primary text-primary-foreground"
+              : "rounded-bl-md bg-card ring-1 ring-border/40"
           )}
         >
-          {formatMessageTime(message.timestamp)}
-        </div>
+          {message.forwardedFrom && (
+            <div
+              className={cn(
+                "mb-1 flex items-center gap-1 text-[11px]",
+                hasMedia ? "px-2.5 pt-1" : "",
+                isOutgoing
+                  ? "text-primary-foreground/70"
+                  : "text-muted-foreground"
+              )}
+              data-testid="forwarded-from"
+            >
+              <Forward className="h-3 w-3" />
+              <span className="italic">
+                Forwarded from {message.forwardedFrom.senderName}
+              </span>
+            </div>
+          )}
 
-        {message.reactions && (
-          <ReactionBadges
-            hasMedia={hasMedia}
-            isOutgoing={isOutgoing}
-            reactions={message.reactions}
-          />
-        )}
+          {message.replyToMessageId && (
+            <ReplyPreview
+              hasMedia={hasMedia}
+              isOutgoing={isOutgoing}
+              onClick={onReplyClick}
+              text={replyText}
+            />
+          )}
+
+          {isDeleted && (
+            <div className="mb-1 flex items-center gap-1 px-2.5 pt-1 text-[11px] opacity-70">
+              <Ban className="h-3 w-3" />
+              <span className="italic">Deleted</span>
+            </div>
+          )}
+
+          {hasMedia && <MediaRenderer isOutgoing={isOutgoing} media={media} />}
+
+          {message.text && (
+            <p
+              className={cn(
+                "whitespace-pre-wrap break-all text-[13px] leading-relaxed",
+                hasMedia && "px-2.5 pt-1"
+              )}
+            >
+              {message.text}
+            </p>
+          )}
+
+          {!(message.text || hasMedia) && (
+            <p className="text-[13px] italic opacity-50">[Empty message]</p>
+          )}
+
+          <div
+            className={cn(
+              "mt-0.5 text-right text-[10px]",
+              hasMedia && "px-2.5 pb-1",
+              isOutgoing
+                ? "text-primary-foreground/50"
+                : "text-muted-foreground/60"
+            )}
+          >
+            {formatMessageTime(message.timestamp)}
+          </div>
+
+          {message.reactions && (
+            <ReactionBadges
+              hasMedia={hasMedia}
+              isOutgoing={isOutgoing}
+              reactions={message.reactions}
+            />
+          )}
+        </div>
       </div>
     </div>
   );
 }
 
+export function makeScrollRequest(messageId: string) {
+  return /* scrollTo: */ { messageId, _aux: Date.now() };
+}
 export function MessageList({
   chatId,
   onBack,
-  targetMessageId,
-}: MessageListProps): React.ReactNode {
+  scrollTo,
+}: {
+  chatId: string;
+  onBack?: () => void;
+  scrollTo?: ReturnType<typeof makeScrollRequest>;
+}): React.ReactNode {
+  const navigate = useNavigate();
+
   const chats = useQuery(api.model.chats.list);
   const clients = useQuery(api.model.clients.list);
   const { results, status, loadMore } = usePaginatedQuery(
@@ -274,24 +326,150 @@ export function MessageList({
     { chatId },
     { initialNumItems: PAGE_SIZE }
   );
+  const orderedMessages = [...results].reverse() as Doc<"messages">[];
 
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const prevChatIdRef = useRef(chatId);
-  const prevCountRef = useRef(0);
-  const isLoadingRef = useRef(false);
-  const scrollAttemptedRef = useRef(false);
+  const msgContainerRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: orderedMessages.length,
+    getScrollElement: () => msgContainerRef.current,
+    estimateSize: () => 64,
+    overscan: 15,
+    getItemKey: (index) => orderedMessages[index]._id,
+    scrollToFn: scrollBehavior,
+  });
+
+  const [highlightState, setHighlight] = useState<{
+    messageId: string;
+    method: "flash";
+    variant: number;
+  } | null>(null);
+  const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const highlight = useRef((messageId: string) => {
+    console.log("hi");
+    if (highlightTimeoutRef.current) {
+      clearTimeout(highlightTimeoutRef.current);
+      highlightTimeoutRef.current = null;
+    }
+    setHighlight((prev) => ({
+      messageId,
+      method: "flash" as const,
+      variant: (prev?.variant ?? -1) + 1,
+    }));
+    highlightTimeoutRef.current = setTimeout(() => setHighlight(null), 1000);
+  }).current;
+  const clearHighlight = useRef(() => {
+    if (highlightTimeoutRef.current) {
+      clearTimeout(highlightTimeoutRef.current);
+      highlightTimeoutRef.current = null;
+    }
+    setHighlight(null);
+  }).current;
+
+  const [pendingTarget, setPendingTarget] = useState<ReturnType<
+    typeof makeScrollRequest
+  > | null>(null);
   const initialScrollDoneRef = useRef(false);
-  const prevTargetRef = useRef(targetMessageId);
-  const [highlightedId, setHighlightedId] = useState<string | null>(null);
+  const paginationRef = useRef({ lastCount: 0, areLoading: false });
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: chatId is the trigger
+  useEffect(() => {
+    initialScrollDoneRef.current = false;
+    setPendingTarget(null);
+    clearHighlight();
+  }, [chatId]);
+
+  useEffect(() => {
+    if (
+      orderedMessages.length > 0 &&
+      !initialScrollDoneRef.current &&
+      !scrollTo &&
+      !pendingTarget
+    ) {
+      initialScrollDoneRef.current = true;
+      virtualizer.scrollToIndex(orderedMessages.length - 1, { align: "end" });
+    }
+  }, [orderedMessages.length, scrollTo, pendingTarget, virtualizer]);
+
+  useEffect(() => {
+    if (scrollTo) {
+      initialScrollDoneRef.current = true;
+      navigate({
+        to: "/chats/$chatId",
+        params: { chatId },
+        search: {},
+        replace: true,
+      });
+      setPendingTarget(scrollTo);
+    }
+  }, [scrollTo, navigate, chatId]);
+
+  useEffect(() => {
+    if (!pendingTarget) {
+      return;
+    }
+
+    const index = orderedMessages.findIndex(
+      (m) => m.messageId === pendingTarget.messageId
+    );
+    if (index >= 0) {
+      initialScrollDoneRef.current = true;
+      const align = getScrollAlign(index, msgContainerRef.current, virtualizer);
+      if (align) {
+        virtualizer.scrollToIndex(index, { align, behavior: "smooth" });
+      }
+      highlight(pendingTarget.messageId);
+      setPendingTarget(null);
+    } else if (status === "CanLoadMore") {
+      loadMore(PAGE_SIZE);
+    } else if (status === "Exhausted") {
+      setPendingTarget(null);
+      // Notify for absent message
+    } else {
+      // Waiting to load here
+    }
+  }, [
+    pendingTarget,
+    orderedMessages,
+    status,
+    loadMore,
+    virtualizer,
+    highlight,
+  ]);
+
+  const handleScroll = (): void => {
+    if (status !== "CanLoadMore" || paginationRef.current.areLoading) {
+      return;
+    }
+    const el = msgContainerRef.current;
+    if (el && el.scrollTop < 200) {
+      paginationRef.current.areLoading = true;
+      loadMore(PAGE_SIZE);
+    }
+  };
+
+  // Scroll preservation after older messages are prepended.
+  useLayoutEffect(() => {
+    const p = paginationRef.current;
+    const currCount = orderedMessages.length;
+    if (p.lastCount > 0 && currCount > p.lastCount && p.areLoading) {
+      const addedCount = currCount - p.lastCount;
+      virtualizer.scrollToIndex(addedCount, { align: "start" });
+      p.areLoading = false;
+    }
+    p.lastCount = currCount;
+  });
 
   const chat = chats?.find((c: { chatId: string }) => c.chatId === chatId);
   const client = chat
     ? clients?.find((c: { _id: string }) => c._id === chat.clientId)
     : undefined;
-
-  // Query returns desc (newest first); reverse for display (oldest at top).
-  const sortedMessages = [...results].reverse() as MessageDoc[];
-  const activeMessageCount = sortedMessages.filter((m) => !m.deleted).length;
+  const messageTextMap = new Map<string, string>();
+  for (const msg of orderedMessages) {
+    if (msg.text) {
+      messageTextMap.set(msg.messageId, msg.text);
+    }
+  }
+  const activeMessageCount = orderedMessages.filter((m) => !m.deleted).length;
 
   // Single indexed scan for all media in this chat (avoids per-message reads
   // that hit Convex's 4096 read limit with large message sets).
@@ -303,98 +481,6 @@ export function MessageList({
     }
   }
 
-  // Virtualizer for the message list.
-  // eslint-disable-next-line react-hooks/incompatible-library
-  const virtualizer = useVirtualizer({
-    count: sortedMessages.length,
-    getScrollElement: () => scrollRef.current,
-    estimateSize: () => 64,
-    overscan: 15,
-    getItemKey: (index) => sortedMessages[index]._id,
-  });
-
-  // Reset state when chat changes.
-  useEffect(() => {
-    prevChatIdRef.current = chatId;
-    prevCountRef.current = 0;
-    isLoadingRef.current = false;
-    scrollAttemptedRef.current = false;
-    initialScrollDoneRef.current = false;
-    setHighlightedId(null);
-  }, [chatId]);
-
-  // Scroll to bottom on initial load (no scroll target).
-  useEffect(() => {
-    if (
-      sortedMessages.length > 0 &&
-      !initialScrollDoneRef.current &&
-      !targetMessageId
-    ) {
-      initialScrollDoneRef.current = true;
-      virtualizer.scrollToIndex(sortedMessages.length - 1, { align: "end" });
-    }
-  }, [sortedMessages.length, targetMessageId, virtualizer]);
-
-  // Scroll-to-message: find the target, load more if needed, scroll instantly.
-  // Also resets state when targetMessageId changes.
-  useEffect(() => {
-    // Reset when target changes.
-    if (prevTargetRef.current !== targetMessageId) {
-      prevTargetRef.current = targetMessageId;
-      scrollAttemptedRef.current = false;
-      setHighlightedId(null);
-    }
-
-    if (!targetMessageId || scrollAttemptedRef.current) {
-      return;
-    }
-
-    const index = sortedMessages.findIndex(
-      (m) => m.messageId === targetMessageId
-    );
-
-    if (index >= 0) {
-      scrollAttemptedRef.current = true;
-      initialScrollDoneRef.current = true;
-      virtualizer.scrollToIndex(index, { align: "center", behavior: "auto" });
-      setHighlightedId(targetMessageId);
-      setTimeout(() => setHighlightedId(null), 2000);
-    } else if (status === "CanLoadMore") {
-      loadMore(PAGE_SIZE);
-    } else if (status === "Exhausted") {
-      // All messages loaded but target not found — give up.
-      scrollAttemptedRef.current = true;
-    }
-    // Otherwise still loading (LoadingFirstPage / LoadingMore) — wait for
-    // sortedMessages/status to change and re-run.
-  }, [targetMessageId, sortedMessages, status, loadMore, virtualizer]);
-
-  // Infinite scroll: load older messages when user scrolls near the top.
-  // Uses scrollTop directly instead of virtualizer.getVirtualItems() because
-  // virtual items can be stale during scroll events fired by scrollToIndex().
-  const handleScroll = (): void => {
-    if (status !== "CanLoadMore" || isLoadingRef.current) {
-      return;
-    }
-    const el = scrollRef.current;
-    if (el && el.scrollTop < 200) {
-      isLoadingRef.current = true;
-      loadMore(PAGE_SIZE);
-    }
-  };
-
-  // Scroll preservation after older messages are prepended.
-  useLayoutEffect(() => {
-    const prevCount = prevCountRef.current;
-    const currCount = sortedMessages.length;
-    if (prevCount > 0 && currCount > prevCount && isLoadingRef.current) {
-      const addedCount = currCount - prevCount;
-      virtualizer.scrollToIndex(addedCount, { align: "start" });
-      isLoadingRef.current = false;
-    }
-    prevCountRef.current = currCount;
-  });
-
   if (status === "LoadingFirstPage") {
     return (
       <div className="flex h-full items-center justify-center">
@@ -402,8 +488,6 @@ export function MessageList({
       </div>
     );
   }
-
-  const virtualItems = virtualizer.getVirtualItems();
 
   return (
     <div className="flex h-full flex-col">
@@ -421,18 +505,18 @@ export function MessageList({
         )}
         <div className="min-w-0 flex-1">
           <h2 className="truncate font-display font-semibold text-sm">
-            {getChatDisplayName(chat)}
+            {displayChatName(chat)}
           </h2>
           <p className="truncate text-muted-foreground/70 text-xs">
             {client && (
-              <span className="mr-1.5">{getClientDisplayName(client)}</span>
+              <span className="mr-1.5">{displayClientName(client)}</span>
             )}
             <span>
               {activeMessageCount}
               {status === "Exhausted" ? "" : "+"} message
               {activeMessageCount === 1 ? "" : "s"}
-              {activeMessageCount !== sortedMessages.length &&
-                ` (${sortedMessages.length - activeMessageCount} deleted)`}
+              {activeMessageCount !== orderedMessages.length &&
+                ` (${orderedMessages.length - activeMessageCount} deleted)`}
             </span>
           </p>
         </div>
@@ -441,9 +525,9 @@ export function MessageList({
       <div
         className="messages-bg flex-1 overflow-y-auto"
         onScroll={handleScroll}
-        ref={scrollRef}
+        ref={msgContainerRef}
       >
-        {sortedMessages.length === 0 ? (
+        {orderedMessages.length === 0 ? (
           <div className="flex h-full items-center justify-center">
             <p className="text-muted-foreground/60 text-sm">No messages yet</p>
           </div>
@@ -460,11 +544,11 @@ export function MessageList({
                 <Loader2 className="h-4 w-4 animate-spin text-muted-foreground/50" />
               </div>
             )}
-            {virtualItems.map((virtualRow) => {
-              const message = sortedMessages[virtualRow.index];
+            {virtualizer.getVirtualItems().map((virtualRow) => {
+              const message = orderedMessages[virtualRow.index];
               const prevMessage =
                 virtualRow.index > 0
-                  ? sortedMessages[virtualRow.index - 1]
+                  ? orderedMessages[virtualRow.index - 1]
                   : undefined;
               const showDateHeader = shouldShowDateHeader(message, prevMessage);
               const isFirst = virtualRow.index === 0;
@@ -485,7 +569,7 @@ export function MessageList({
                 >
                   {isFirst &&
                     status === "Exhausted" &&
-                    sortedMessages.length >= PAGE_SIZE && (
+                    orderedMessages.length >= PAGE_SIZE && (
                       <p className="py-2 text-center text-muted-foreground/40 text-xs">
                         Beginning of conversation
                       </p>
@@ -499,13 +583,31 @@ export function MessageList({
                       <div className="h-px flex-1 bg-border/50" />
                     </div>
                   )}
-                  <div className="px-4 py-1">
-                    <MessageBubble
-                      highlighted={highlightedId === message.messageId}
-                      media={mediaMap.get(message.messageId)}
-                      message={message}
-                    />
-                  </div>
+                  <MessageListItem
+                    highlight={
+                      highlightState?.messageId === message.messageId
+                        ? highlightState
+                        : undefined
+                    }
+                    media={mediaMap.get(message.messageId)}
+                    message={message}
+                    onReplyClick={
+                      message.replyToMessageId
+                        ? () => {
+                            if (message.replyToMessageId) {
+                              setPendingTarget(
+                                makeScrollRequest(message.replyToMessageId)
+                              );
+                            }
+                          }
+                        : undefined
+                    }
+                    replyText={
+                      message.replyToMessageId
+                        ? messageTextMap.get(message.replyToMessageId)
+                        : undefined
+                    }
+                  />
                 </div>
               );
             })}

--- a/bins/crm-chat-web/src/index.css
+++ b/bins/crm-chat-web/src/index.css
@@ -160,7 +160,15 @@ input[type="search"]::-webkit-search-cancel-button {
 }
 
 /* Highlight animation for scroll-to-message */
-@keyframes highlight-outline-fade {
+@keyframes highlight-outline-fade-a {
+  0% {
+    box-shadow: 0 0 0 3px oklch(0.85 0.17 85);
+  }
+  100% {
+    box-shadow: 0 0 0 3px transparent;
+  }
+}
+@keyframes highlight-outline-fade-b {
   0% {
     box-shadow: 0 0 0 3px oklch(0.85 0.17 85);
   }
@@ -169,7 +177,15 @@ input[type="search"]::-webkit-search-cancel-button {
   }
 }
 
-@keyframes highlight-bg-fade {
+@keyframes highlight-bg-fade-a {
+  0% {
+    background-color: oklch(0.85 0.17 85 / 12%);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+@keyframes highlight-bg-fade-b {
   0% {
     background-color: oklch(0.85 0.17 85 / 12%);
   }
@@ -179,17 +195,17 @@ input[type="search"]::-webkit-search-cancel-button {
 }
 
 .animate-highlight-outline-a {
-  animation: highlight-outline-fade 1s ease-out forwards;
+  animation: highlight-outline-fade-a 1s ease-out forwards;
 }
 .animate-highlight-outline-b {
-  animation: highlight-outline-fade 1s ease-out forwards;
+  animation: highlight-outline-fade-b 1s ease-out forwards;
 }
 
 .animate-highlight-bg-a {
-  animation: highlight-bg-fade 1s ease-out forwards;
+  animation: highlight-bg-fade-a 1s ease-out forwards;
 }
 .animate-highlight-bg-b {
-  animation: highlight-bg-fade 1s ease-out forwards;
+  animation: highlight-bg-fade-b 1s ease-out forwards;
 }
 
 /* Subtle message area background pattern (dark mode only) */

--- a/bins/crm-chat-web/src/index.css
+++ b/bins/crm-chat-web/src/index.css
@@ -159,6 +159,33 @@ input[type="search"]::-webkit-search-cancel-button {
   }
 }
 
+/* Highlight animation for scroll-to-message */
+@keyframes highlight-outline-fade {
+  0% {
+    box-shadow: 0 0 0 3px oklch(0.85 0.17 85);
+  }
+  100% {
+    box-shadow: 0 0 0 3px transparent;
+  }
+}
+
+@keyframes highlight-bg-fade {
+  0% {
+    background-color: oklch(0.85 0.17 85 / 12%);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
+.animate-highlight-outline {
+  animation: highlight-outline-fade 2s ease-out forwards;
+}
+
+.animate-highlight-bg {
+  animation: highlight-bg-fade 2s ease-out forwards;
+}
+
 /* Subtle message area background pattern (dark mode only) */
 .dark .messages-bg {
   background-image: radial-gradient(oklch(1 0 0 / 2%) 1px, transparent 1px);

--- a/bins/crm-chat-web/src/index.css
+++ b/bins/crm-chat-web/src/index.css
@@ -178,12 +178,18 @@ input[type="search"]::-webkit-search-cancel-button {
   }
 }
 
-.animate-highlight-outline {
-  animation: highlight-outline-fade 2s ease-out forwards;
+.animate-highlight-outline-a {
+  animation: highlight-outline-fade 1s ease-out forwards;
+}
+.animate-highlight-outline-b {
+  animation: highlight-outline-fade 1s ease-out forwards;
 }
 
-.animate-highlight-bg {
-  animation: highlight-bg-fade 2s ease-out forwards;
+.animate-highlight-bg-a {
+  animation: highlight-bg-fade 1s ease-out forwards;
+}
+.animate-highlight-bg-b {
+  animation: highlight-bg-fade 1s ease-out forwards;
 }
 
 /* Subtle message area background pattern (dark mode only) */

--- a/bins/crm-chat-web/src/utils/display.ts
+++ b/bins/crm-chat-web/src/utils/display.ts
@@ -1,0 +1,20 @@
+export function displayClientName(
+  client: { kind: string; telegramId: string } | undefined
+): string {
+  if (!client) {
+    return "";
+  }
+  return `${client.kind} • ${client.telegramId}`;
+}
+
+export function displayChatName(
+  chat: { pinnedName?: string; chatId: string } | undefined
+): string {
+  if (!chat) {
+    return "Chat";
+  }
+  if (chat.pinnedName) {
+    return chat.pinnedName;
+  }
+  return `Chat ${chat.chatId.slice(0, 8)}`;
+}

--- a/bins/crm-chat-web/src/utils/format.ts
+++ b/bins/crm-chat-web/src/utils/format.ts
@@ -1,0 +1,26 @@
+export function formatMessageTime(ts: number): string {
+  const date = new Date(ts);
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export function formatDateHeader(ts: number): string {
+  const date = new Date(ts);
+  const now = new Date();
+  const isToday = date.toDateString() === now.toDateString();
+
+  if (isToday) {
+    return "Today";
+  }
+
+  const yesterday = new Date(now);
+  yesterday.setDate(yesterday.getDate() - 1);
+  if (date.toDateString() === yesterday.toDateString()) {
+    return "Yesterday";
+  }
+
+  return date.toLocaleDateString([], {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+}

--- a/bins/crm-chat-web/tests/helpers.ts
+++ b/bins/crm-chat-web/tests/helpers.ts
@@ -226,7 +226,6 @@ export async function seedMessage(
     deleted?: boolean;
     timestamp?: number;
     replyToMessageId?: string;
-    replyToText?: string;
     forwardedFrom?: { senderName: string; date?: number };
     reactions?: Array<{
       emoji: string;
@@ -248,7 +247,6 @@ export async function seedMessage(
     deleted: opts?.deleted ?? false,
     timestamp: opts?.timestamp ?? Date.now(),
     replyToMessageId: opts?.replyToMessageId,
-    replyToText: opts?.replyToText,
     forwardedFrom: opts?.forwardedFrom,
     reactions: opts?.reactions,
   });

--- a/bins/crm-chat-web/tests/replies.spec.ts
+++ b/bins/crm-chat-web/tests/replies.spec.ts
@@ -75,7 +75,6 @@ test.describe("Replies — Backend", () => {
       robot,
       {
         replyToMessageId: originalMsgId,
-        replyToText: "Original message",
         timestamp: Date.now(),
       }
     );
@@ -86,13 +85,11 @@ test.describe("Replies — Backend", () => {
     })) as Array<{
       messageId: string;
       replyToMessageId?: string;
-      replyToText?: string;
     }>;
 
     const reply = msgs.find((m) => m.messageId === replyMsgId);
     expect(reply).toBeTruthy();
     expect(reply?.replyToMessageId).toBe(originalMsgId);
-    expect(reply?.replyToText).toBe("Original message");
   });
 
   test("message without reply has no reply fields", async () => {
@@ -162,7 +159,6 @@ test.describe("Replies — UI", () => {
       robot,
       {
         replyToMessageId: originalId,
-        replyToText: "I said something important",
         timestamp: Date.now(),
       }
     );
@@ -201,7 +197,6 @@ test.describe("Replies — UI", () => {
       robot,
       {
         replyToMessageId: longMsgId,
-        replyToText: longText,
         timestamp: Date.now(),
       }
     );

--- a/bins/crm-worker/src/services/chat_scanner.rs
+++ b/bins/crm-worker/src/services/chat_scanner.rs
@@ -203,6 +203,8 @@ pub async fn scan_chat_messages(
                 replyToMessageId: msg
                     .reply_to_message_id
                     .map(|id| format!("{}:{}", req.chat_id, id)),
+                forwardedFrom: None,
+                reactions: None,
             })
             .await
             .map_err(|e| WorkerError::MutationFailed(e.to_string()))?;

--- a/bins/crm-worker/src/services/chat_scanner.rs
+++ b/bins/crm-worker/src/services/chat_scanner.rs
@@ -200,6 +200,9 @@ pub async fn scan_chat_messages(
                     .media_summary
                     .as_ref()
                     .map(|s| to_upsert_media_kind(s.kind)),
+                replyToMessageId: msg
+                    .reply_to_message_id
+                    .map(|id| format!("{}:{}", req.chat_id, id)),
             })
             .await
             .map_err(|e| WorkerError::MutationFailed(e.to_string()))?;

--- a/bins/crm-worker/src/services/update_listener.rs
+++ b/bins/crm-worker/src/services/update_listener.rs
@@ -190,6 +190,10 @@ async fn process_update(
             let message_id = format!("{}:{}", chat_id, msg.external_id);
             let ts = msg.timestamp_ms.map(|t| t as f64).unwrap_or(0.0);
 
+            let reply_to_message_id = msg
+                .reply_to_message_id
+                .map(|id| format!("{}:{}", chat_id, id));
+
             convex
                 .messages_worker_upsert_message(MessagesWorkerUpsertMessageArgs {
                     messageId: message_id,
@@ -207,6 +211,7 @@ async fn process_update(
                         .media_summary
                         .as_ref()
                         .map(|s| to_upsert_media_kind(s.kind)),
+                    replyToMessageId: reply_to_message_id,
                 })
                 .await
                 .map_err(|e| WorkerError::MutationFailed(e.to_string()))?;

--- a/bins/crm-worker/src/services/update_listener.rs
+++ b/bins/crm-worker/src/services/update_listener.rs
@@ -212,6 +212,8 @@ async fn process_update(
                         .as_ref()
                         .map(|s| to_upsert_media_kind(s.kind)),
                     replyToMessageId: reply_to_message_id,
+                    forwardedFrom: None,
+                    reactions: None,
                 })
                 .await
                 .map_err(|e| WorkerError::MutationFailed(e.to_string()))?;

--- a/libs/messanger-interface/src/lib.rs
+++ b/libs/messanger-interface/src/lib.rs
@@ -122,6 +122,7 @@ mod tests {
                 timestamp_ms: Some(1000),
                 media_external_id: Some(media1.external_id.clone()),
                 media_summary: Some(media1.clone()),
+                reply_to_message_id: None,
             };
 
             let mut messages = HashMap::new();
@@ -367,6 +368,7 @@ mod tests {
                 timestamp_ms: Some(1000),
                 media_external_id: None,
                 media_summary: None,
+                reply_to_message_id: None,
             },
             MessageSummary {
                 external_id: "msg:2".to_string(),
@@ -377,6 +379,7 @@ mod tests {
                 timestamp_ms: Some(2000),
                 media_external_id: None,
                 media_summary: None,
+                reply_to_message_id: None,
             },
         ];
 
@@ -502,6 +505,7 @@ mod tests {
             timestamp_ms: Some(1000),
             media_external_id: None,
             media_summary: None,
+            reply_to_message_id: None,
         });
 
         let json = serde_json::to_string(&update).unwrap();
@@ -542,6 +546,7 @@ mod tests {
             timestamp_ms: Some(1000),
             media_external_id: Some("media:1".to_string()),
             media_summary: None,
+            reply_to_message_id: None,
         };
 
         let json = serde_json::to_string(&msg).unwrap();

--- a/libs/messanger-interface/src/message.rs
+++ b/libs/messanger-interface/src/message.rs
@@ -24,4 +24,6 @@ pub struct MessageSummary {
     pub media_external_id: Option<ExternalId>,
     /// Classified media summary with metadata (if media is present).
     pub media_summary: Option<MediaSummary>,
+    /// Platform-specific ID of the message this is replying to (if any).
+    pub reply_to_message_id: Option<i32>,
 }

--- a/libs/messanger-telegram/src/messenger.rs
+++ b/libs/messanger-telegram/src/messenger.rs
@@ -474,7 +474,7 @@ fn convert_tg_update(update: &TgUpdate) -> Update {
                     .media()
                     .map(|_| format!("media:{}:{}", chat_id, message.id())),
                 media_summary,
-                reply_to_message_id: message.reply_to_message_id()
+                reply_to_message_id: message.reply_to_message_id(),
             })
         }
         TgUpdate::MessageEdited(message) => {
@@ -505,7 +505,7 @@ fn convert_tg_update(update: &TgUpdate) -> Update {
                     .media()
                     .map(|_| format!("media:{}:{}", chat_id, message.id())),
                 media_summary,
-                reply_to_message_id: message.reply_to_message_id()
+                reply_to_message_id: message.reply_to_message_id(),
             })
         }
         TgUpdate::MessageDeleted(deleted) => {

--- a/libs/messanger-telegram/src/messenger.rs
+++ b/libs/messanger-telegram/src/messenger.rs
@@ -721,6 +721,7 @@ impl MessengerClient for TelegramClient {
                             .media()
                             .map(|_| format!("media:{}:{}", chat_bare_id, msg.id())),
                         media_summary,
+                        reply_to_message_id: msg.reply_to_message_id(),
                     };
                     count += 1;
                     // If receiver is dropped, stop producing to avoid unnecessary work

--- a/libs/messanger-telegram/src/messenger.rs
+++ b/libs/messanger-telegram/src/messenger.rs
@@ -474,6 +474,7 @@ fn convert_tg_update(update: &TgUpdate) -> Update {
                     .media()
                     .map(|_| format!("media:{}:{}", chat_id, message.id())),
                 media_summary,
+                reply_to_message_id: message.reply_to_message_id()
             })
         }
         TgUpdate::MessageEdited(message) => {
@@ -504,6 +505,7 @@ fn convert_tg_update(update: &TgUpdate) -> Update {
                     .media()
                     .map(|_| format!("media:{}:{}", chat_id, message.id())),
                 media_summary,
+                reply_to_message_id: message.reply_to_message_id()
             })
         }
         TgUpdate::MessageDeleted(deleted) => {


### PR DESCRIPTION
Changed schema so the reply messages optionally store the replyToMessageId. Text is dropped as in my opinion it's better to just fetch the needed messages afterwards than storing their parts. They might be edited at the very least, and then the synchronization must be accounted for.

## Summary by Sourcery

Improve chat reply rendering and message highlighting by relying on stored reply IDs instead of duplicated reply text, and wire reply metadata through the backend pipeline.

Bug Fixes:
- Ensure replies reference the correct original message text by looking it up from the message list rather than persisting a separate reply text field.
- Fix scroll-to-message behavior so highlighting reliably resets and replays when navigating to or re-clicking replies, and clear search params after initial jump.

Enhancements:
- Add a reusable reply preview component that supports clicking to navigate to the referenced message and adapts styling based on media and direction.
- Introduce subtle background and outline highlight animations for messages when jumped to from links or replies.

Tests:
- Update backend and UI reply tests and seeding helpers to reflect removal of the persisted reply text field and use of reply-to IDs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replies now reference message IDs so reply previews jump to and highlight the referenced message.
  * Added scroll-to request API with smoother scrolling and transient highlight animations.
  * New utilities for consistent chat/client name and timestamp/date display.

* **Bug Fixes / Cleanup**
  * Removed legacy reply-text field; reply previews derive from the referenced message content.

* **Tests**
  * Tests and helpers updated to match the new reply behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->